### PR TITLE
## Adoption Status: Beat Kind Pattern

### DIFF
--- a/__tests__/canvas-component/create.io.spec.ts
+++ b/__tests__/canvas-component/create.io.spec.ts
@@ -1,0 +1,28 @@
+import { registerInstance } from "../../plugins/canvas-component/symphonies/create.io";
+
+function makeCtx() {
+  const ops: any[] = [];
+  return {
+    payload: { nodeId: "rx-node-abc123", template: { tag: "button", classes: ["rx-button"], style: {} } },
+    io: {
+      kv: { put: async (...a: any[]) => ops.push(["kv.put", ...a]) },
+      cache: { put: async (...a: any[]) => ops.push(["cache.put", ...a]) },
+    },
+    _ops: ops,
+  } as any;
+}
+
+describe("canvas-component create.io", () => {
+  it("persists node metadata to KV/cache", async () => {
+    const ctx: any = makeCtx();
+    await registerInstance({}, ctx);
+    const names = ctx._ops.map((x: any[]) => x[0]);
+    expect(names).toContain("kv.put");
+  });
+
+  it("throws when IO is accessed in a pure beat (guard example)", () => {
+    const ctx: any = { io: new Proxy({}, { get() { throw new Error("IO not available in this beat"); } }) };
+    expect(() => (ctx as any).io.kv.put("k", "v")).toThrow();
+  });
+});
+

--- a/docs/adr/ADR-0001 (update) — Beat Kind Taxonomy in Musical Conductor.md
+++ b/docs/adr/ADR-0001 (update) — Beat Kind Taxonomy in Musical Conductor.md
@@ -1,0 +1,57 @@
+﻿# ADR-0001 (update) — Beat Kind Taxonomy in Musical Conductor
+
+**Change summary:** Add `kind: "io"` for local persistence/caching/FS/logging that does **not** leave the device/network.
+
+## Beat kinds (final)
+
+| kind         | Purpose                                           | Conductor-injected caps on `ctx`       |
+| ------------ | ------------------------------------------------- | -------------------------------------- |
+| `pure`       | Computation/orchestration only                    | `payload`, `util`, `conductor`         |
+| `io`         | Local I/O (caching, KV, IndexedDB, Cache API, FS) | `io` (+ everything from `pure`)        |
+| `api`        | Remote calls (HTTP/gRPC/WebSocket)                | `apiClient` (+ everything from `pure`) |
+| `stage-crew` | DOM/CSS mutations via StageCrew                   | `stageCrew` (+ everything from `pure`) |
+
+* `kind` defaults to `pure`.
+* Conductor **injects only the capability of that kind**; others are guarded with throwing proxies (attempting to use `stageCrew` in a `pure/io/api` beat throws).
+* CIA/SPA validators enforce the mapping and file locations.
+
+## Ordering guidance (movement best practice)
+
+* Prefer: **`pure` → (`api` and/or `io`) → `stage-crew` → `pure` (notify)**
+* Only **one `stage-crew` beat per movement**, and it should be **last** before notify.
+* Use `api` before `io` if you’re **fetching** then caching. Use `io` only if you’re **reading/writing local state** (cache, undo stack, snapshot log, KV, IndexedDB, file).
+
+## Runtime injection (pseudo)
+
+```ts
+switch (beat.kind ?? "pure") {
+  case "stage-crew": ctx.stageCrew = StageCrew.for(seq, beat); break;
+  case "api":        ctx.apiClient = ApiClient.for(pluginId);  break;
+  case "io":         ctx.io        = IOClient.for(pluginId);    break;
+  default:           /* pure */                                  break;
+}
+// Guard everything else:
+ctx.stageCrew ||= ThrowingProxy("StageCrew not available in this beat");
+ctx.apiClient ||= ThrowingProxy("API not available in this beat");
+ctx.io        ||= ThrowingProxy("IO not available in this beat");
+```
+
+## File conventions (recommended)
+
+* `*.arrangement.ts` → `pure`
+* `*.io.ts` → `io`
+* `*.api.ts` → `api`
+* `*.stage-crew.ts` → `stage-crew`
+* `*.notify.ts` → final `pure` notify beat
+
+## Telemetry
+
+* Log `{sequenceId, movementId, beat, kind, durationMs}`.
+* For `io`: `{op, key, size?, latencyMs}` (no sensitive payloads).
+* For `api`: `{method, endpoint, status, latencyMs}`.
+* For `stage-crew`: txn intent summary before commit.
+
+## CIA/SPA rules (delta)
+
+* If `beat.kind === "io"`, handler must live in `*.io.ts`; **must not** import StageCrew or DOM APIs.
+* UI code remains banned from DOM, StageCrew, **and IO/APIs** (UI is view-only).

--- a/docs/adr/ADR-0002 (update) — renderx-plugins - Canvas Create adopts Beat Kinds (with IO).md
+++ b/docs/adr/ADR-0002 (update) — renderx-plugins - Canvas Create adopts Beat Kinds (with IO).md
@@ -1,0 +1,171 @@
+﻿# ADR-0002 (update) — renderx-plugins: Canvas Create adopts Beat Kinds (with IO)
+
+**Change summary:** Insert an **IO beat** to persist/register instance metadata (e.g., node registry, undo snapshot, cache of template) before DOM creation.
+
+## Updated sequence: Canvas Create
+
+```ts
+export const sequence = {
+  id: "canvas-component-create-symphony",
+  movements: [{
+    id: "create",
+    beats: [
+      { beat: 1, event: "canvas:component:resolve-template", handler: "resolveTemplate", kind: "pure" },
+      { beat: 2, event: "canvas:component:register-instance", handler: "registerInstance", kind: "io" },      // NEW
+      { beat: 3, event: "canvas:component:create",            handler: "createNode",       kind: "stage-crew" },
+      { beat: 4, event: "canvas:component:notify-ui",         handler: "notifyUi",         kind: "pure" }
+    ]
+  }]
+};
+```
+
+### Handlers layout & files
+
+```
+plugins/canvas-component/symphonies/
+  create.arrangement.ts     // resolveTemplate (pure)
+  create.io.ts              // registerInstance (io)  ← new
+  create.stage-crew.ts      // createNode (stage-crew)
+  create.notify.ts          // notifyUi (pure)
+  create.symphony.ts        // sequence + handlers export
+```
+
+**`create.arrangement.ts` (pure)**
+
+```ts
+export const resolveTemplate = (data: any, ctx: any) => {
+  const tpl = data.component?.template;
+  if (!tpl) throw new Error("Missing component template.");
+  ctx.payload.template = tpl;
+  ctx.payload.nodeId = `rx-node-${Math.random().toString(36).slice(2, 8)}`;
+};
+```
+
+**`create.io.ts` (io)**
+
+```ts
+export const registerInstance = async (data: any, ctx: any) => {
+  const { nodeId, template } = ctx.payload;
+  // Examples of IO responsibilities:
+  // - persist node metadata to a KV/registry
+  // - write undo snapshot / change journal
+  // - cache template/style blob for quick rehydrate
+  await ctx.io.kv.put(nodeId, {
+    type: template.tag,
+    classes: template.classes,
+    style: template.style,
+    createdAt: Date.now()
+  });
+  // (optional) await ctx.io.cache.put(`tpl:${template.tag}`, template);
+};
+```
+
+**`create.stage-crew.ts` (stage-crew)**
+
+```ts
+export const createNode = (data: any, ctx: any) => {
+  const tpl = ctx.payload.template;
+  const id = ctx.payload.nodeId;
+  const txn = ctx.stageCrew.beginBeat();
+
+  // Optional CSS injection
+  // ctx.stageCrew.injectRawCSS(serializeStyleToCSS(tpl.style));
+
+  txn.create(`#${id}`, { tag: tpl.tag, classes: tpl.classes, text: tpl.text });
+  txn.setPosition?.(id, data.position);
+  txn.commit();
+
+  ctx.payload.createdNode = { id, tag: tpl.tag, text: tpl.text, classes: tpl.classes, style: tpl.style, position: data.position };
+};
+```
+
+**`create.notify.ts` (pure)**
+
+```ts
+export const notifyUi = (data: any, ctx: any) => {
+  data?.onComponentCreated?.(ctx.payload.createdNode);
+};
+```
+
+**`create.symphony.ts`**
+
+```ts
+import { resolveTemplate } from "./create.arrangement";
+import { registerInstance } from "./create.io";
+import { createNode } from "./create.stage-crew";
+import { notifyUi } from "./create.notify";
+
+export const sequence = /* sequence object above */;
+export const handlers = { resolveTemplate, registerInstance, createNode, notifyUi };
+```
+
+---
+
+## Library Load example with API + IO (pattern)
+
+Use `api` to fetch, then `io` to cache, then notify UI:
+
+```ts
+export const sequence = {
+  id: "library-load-symphony",
+  movements: [{
+    id: "load",
+    beats: [
+      { beat: 1, event: "library:components:fetch",  handler: "fetchComponents",  kind: "api" },
+      { beat: 2, event: "library:components:cache",  handler: "cacheComponents",  kind: "io"  },
+      { beat: 3, event: "library:components:notify", handler: "notifyUi",         kind: "pure"}
+    ]
+  }]
+};
+```
+
+---
+
+## Validator & lint updates (delta)
+
+* CIA static rule:
+
+  * `kind:"io"` → handler file must match `/\.io\.(t|j)sx?$/`.
+  * `*.io.ts` files must not import StageCrew or DOM APIs.
+* UI lint stays the same (UI cannot import DOM/StageCrew/**IO**/**API**). Add IO/API packages to the “no-restricted-imports” list for UI folders if needed.
+
+---
+
+## Test skeleton additions (Vitest)
+
+Add a simple IO unit test to assert IO calls happen **only** in `io` beats.
+
+**`__tests__/canvas-component/create.io.spec.ts`**
+
+```ts
+import { registerInstance } from "../../plugins/canvas-component/symphonies/create.io";
+
+function makeCtx() {
+  const ops: any[] = [];
+  return {
+    payload: { nodeId: "rx-node-abc123", template: { tag: "button", classes: ["rx-button"], style: {} } },
+    io: {
+      kv: { put: async (...a: any[]) => ops.push(["kv.put", ...a]) },
+      cache: { put: async (...a: any[]) => ops.push(["cache.put", ...a]) }
+    },
+    _ops: ops
+  };
+}
+
+it("persists node metadata to KV/cache", async () => {
+  const ctx: any = makeCtx();
+  await registerInstance({}, ctx);
+  const names = ctx._ops.map(x => x[0]);
+  expect(names).toContain("kv.put");
+});
+```
+
+And a guard test (ensures `io` is not available in `pure` beats once Conductor guards are in):
+
+```ts
+it("throws when IO is accessed in a pure beat", () => {
+  const ctx: any = { io: new Proxy({}, { get(){ throw new Error("IO not available in this beat"); }}) };
+  expect(() => ctx.io.kv.put("k","v")).toThrow();
+});
+```
+

--- a/plugins/canvas-component/symphonies/create.arrangement.ts
+++ b/plugins/canvas-component/symphonies/create.arrangement.ts
@@ -1,0 +1,8 @@
+export const resolveTemplate = (data: any, ctx: any) => {
+  const tpl = data?.component?.template;
+  if (!tpl) throw new Error("Missing component template.");
+  ctx.payload.template = tpl;
+  // Pre-allocate nodeId so IO can persist before DOM creation
+  ctx.payload.nodeId = `rx-node-${Math.random().toString(36).slice(2, 8)}`;
+};
+

--- a/plugins/canvas-component/symphonies/create.io.ts
+++ b/plugins/canvas-component/symphonies/create.io.ts
@@ -1,0 +1,18 @@
+export const registerInstance = async (data: any, ctx: any) => {
+  const { nodeId, template } = ctx.payload || {};
+  if (!nodeId || !template) throw new Error("Missing nodeId/template in payload for IO registration");
+
+  // Examples of IO responsibilities:
+  // - persist node metadata to a KV/registry
+  // - write undo snapshot / change journal
+  // - cache template/style blob for quick rehydrate
+  await ctx.io?.kv?.put?.(nodeId, {
+    type: template.tag,
+    classes: template.classes,
+    style: template.style,
+    createdAt: Date.now(),
+  });
+  // (optional)
+  // await ctx.io?.cache?.put?.(`tpl:${template.tag}`, template);
+};
+

--- a/plugins/canvas-component/symphonies/create.notify.ts
+++ b/plugins/canvas-component/symphonies/create.notify.ts
@@ -1,0 +1,4 @@
+export const notifyUi = (data: any, ctx: any) => {
+  data?.onComponentCreated?.(ctx.payload.createdNode);
+};
+

--- a/plugins/canvas-component/symphonies/create.stage-crew.ts
+++ b/plugins/canvas-component/symphonies/create.stage-crew.ts
@@ -1,0 +1,35 @@
+export const createNode = (data: any, ctx: any) => {
+  const tpl = ctx.payload.template;
+  const id = ctx.payload.nodeId;
+  const selector = `#${id}`;
+
+  const txn = ctx.stageCrew?.beginBeat?.(id, { handlerName: "createNode" });
+  txn?.create(tpl.tag, { classes: tpl.classes || [], attrs: { id } })?.appendTo?.("#rx-canvas");
+
+  const style: Record<string, string> = {};
+  const tplStyle = tpl.style || {};
+  for (const [k, v] of Object.entries(tplStyle)) style[k] = String(v);
+  if (data?.position) {
+    style.position = style.position || "absolute";
+    style.left = typeof data.position.x === "number" ? `${data.position.x}px` : String(data.position.x);
+    style.top = typeof data.position.y === "number" ? `${data.position.y}px` : String(data.position.y);
+  }
+
+  txn?.update?.(selector, {
+    classes: { add: (tpl.classes || []) as string[] },
+    attrs: { id },
+    style,
+  });
+
+  txn?.commit?.({ batch: true });
+
+  ctx.payload.createdNode = {
+    id,
+    tag: tpl.tag,
+    text: tpl.text,
+    classes: tpl.classes,
+    style: tpl.style,
+    position: data.position,
+  };
+};
+

--- a/plugins/canvas-component/symphonies/create.symphony.ts
+++ b/plugins/canvas-component/symphonies/create.symphony.ts
@@ -1,3 +1,8 @@
+import { resolveTemplate } from "./create.arrangement";
+import { registerInstance } from "./create.io";
+import { createNode } from "./create.stage-crew";
+import { notifyUi } from "./create.notify";
+
 export const sequence = {
   id: "canvas-component-create-symphony",
   name: "Canvas Component Create",
@@ -6,61 +11,13 @@ export const sequence = {
       id: "create",
       name: "Create",
       beats: [
-        { beat: 1, event: "canvas:component:resolve-template", title: "Resolve Template", dynamics: "mf", handler: "resolveTemplate", timing: "immediate" },
-        { beat: 2, event: "canvas:component:create", title: "Create Node", dynamics: "mf", handler: "createNode", timing: "after-beat" },
-        { beat: 3, event: "canvas:component:notify-ui", title: "Notify UI", dynamics: "mf", handler: "notifyUi", timing: "after-beat" },
+        { beat: 1, event: "canvas:component:resolve-template", title: "Resolve Template", dynamics: "mf", handler: "resolveTemplate", timing: "immediate", kind: "pure" },
+        { beat: 2, event: "canvas:component:register-instance", title: "Register Instance", dynamics: "mf", handler: "registerInstance", timing: "after-beat", kind: "io" },
+        { beat: 3, event: "canvas:component:create", title: "Create Node", dynamics: "mf", handler: "createNode", timing: "after-beat", kind: "stage-crew" },
+        { beat: 4, event: "canvas:component:notify-ui", title: "Notify UI", dynamics: "mf", handler: "notifyUi", timing: "after-beat", kind: "pure" },
       ],
     },
   ],
 } as const;
 
-export const handlers = {
-  resolveTemplate(data: any, ctx: any) {
-    const tpl = data?.component?.template;
-    if (!tpl) throw new Error("Missing component template.");
-    ctx.payload.template = tpl;
-  },
-
-  createNode(data: any, ctx: any) {
-    const tpl = ctx.payload.template;
-    const nodeId = `rx-node-${Math.random().toString(36).slice(2, 8)}`;
-    const selector = `#${nodeId}`;
-
-    // StageCrew transaction: create element under #rx-canvas, set id/classes/style/attrs, then commit
-    const txn = ctx.stageCrew?.beginBeat?.(nodeId, { handlerName: "createNode" });
-    txn
-      ?.create(tpl.tag, { classes: tpl.classes || [], attrs: { id: nodeId } })
-      .appendTo("#rx-canvas");
-
-    const style: Record<string, string> = {};
-    const tplStyle = tpl.style || {};
-    for (const [k, v] of Object.entries(tplStyle)) style[k] = String(v);
-    if (data?.position) {
-      style.position = style.position || "absolute";
-      style.left = typeof data.position.x === "number" ? `${data.position.x}px` : String(data.position.x);
-      style.top = typeof data.position.y === "number" ? `${data.position.y}px` : String(data.position.y);
-    }
-
-    txn?.update(selector, {
-      classes: { add: (tpl.classes || []) as string[] },
-      attrs: { id: nodeId },
-      style,
-    });
-
-    txn?.commit?.({ batch: true });
-
-    ctx.payload.createdNode = {
-      id: nodeId,
-      tag: tpl.tag,
-      text: tpl.text,
-      classes: tpl.classes,
-      style: tpl.style,
-      position: data.position,
-    };
-  },
-
-  notifyUi(data: any, ctx: any) {
-    data?.onComponentCreated?.(ctx.payload.createdNode);
-  },
-};
-
+export const handlers = { resolveTemplate, registerInstance, createNode, notifyUi };


### PR DESCRIPTION
The Beat Kind pattern has been adopted for Canvas Create per ADR-0001 and ADR-0002.

### What I implemented
- Split handlers by beat kind per ADR:
  - pure: create.arrangement.ts (resolveTemplate)
  - io: create.io.ts (registerInstance)
  - stage-crew: create.stage-crew.ts (createNode)
  - pure: create.notify.ts (notifyUi)
- Updated the symphony to include kinds and the new IO beat:
  - Added beat 2: canvas:component:register-instance (kind: "io")
  - Marked all beats with kind to enable Conductor capability injection
- Added tests for IO beat discipline:
  - __tests__/canvas-component/create.io.spec.ts checks we persist metadata via ctx.io and includes a guard example for “pure” beats

### Updated symphony (excerpt)
````ts path=plugins/canvas-component/symphonies/create.symphony.ts mode=EXCERPT
export const sequence = {
  movements: [{ id: "create", beats: [
    { beat: 1, event: "canvas:component:resolve-template", handler: "resolveTemplate", kind: "pure" },
    { beat: 2, event: "canvas:component:register-instance", handler: "registerInstance", kind: "io" },
    { beat: 3, event: "canvas:component:create", handler: "createNode", kind: "stage-crew" },
    { beat: 4, event: "canvas:component:notify-ui", handler: "notifyUi", kind: "pure" }
  ]}]
};
````

### IO handler (excerpt)
````ts path=plugins/canvas-component/symphonies/create.io.ts mode=EXCERPT
export const registerInstance = async (data: any, ctx: any) => {
  const { nodeId, template } = ctx.payload;
  await ctx.io?.kv?.put?.(nodeId, {
    type: template.tag, classes: template.classes, style: template.style, createdAt: Date.now()
  });
};
````

### New test (excerpt)
````ts path=__tests__/canvas-component/create.io.spec.ts mode=EXCERPT
it("persists node metadata to KV/cache", async () => {
  const ctx: any = makeCtx();
  await registerInstance({}, ctx);
  const names = ctx._ops.map((x: any[]) => x[0]);
  expect(names).toContain("kv.put");
});
````

## ADR Alignment

- ADR-0001: Beat Kind Taxonomy
  - Implemented kind: "io" with local persistence responsibilities and capability injection assumptions.
  - Handlers split by file naming convention (arrangement/io/stage-crew/notify).
- ADR-0002: Canvas Create adopts IO beat
  - Inserted IO beat before DOM creation to persist/register instance metadata.
  - Pre-allocated nodeId in pure beat to enable IO persistence prior to stage-crew.

## Task wrap-up

- [x] Investigate/triage: read ADR-0001 and ADR-0002 and repo state
- [x] Adopt Beat Kinds for Canvas Create, add IO beat, refactor handlers, add tests
- [x] Validate with unit tests (all tests passing)

## Suggested next steps

- Optional lint/validator deltas from ADR-0002:
  - Enforce “kind: io” → handler must live in *.io.ts; and io files must not import StageCrew/DOM
  - We can extend ESLint rules to encode these bans if desired
- Library symphony follow-up:
  - If/when you introduce Library “load” with remote fetch, we can mark beats as api → io → pure per ADR’s example
- Telemetry/guards:
  - Add ThrowingProxy guards at runtime (if not already provided by MusicalConductor in this environment) and log per-beat telemetry