### PR TITLE
test(#5): update tests for DOM-based stage-crew behavior; extract CanvasDrop helper; add jsdom dev dep

### DIFF
--- a/__tests__/canvas-component/create.spec.ts
+++ b/__tests__/canvas-component/create.spec.ts
@@ -1,3 +1,5 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
 import { handlers } from "../../plugins/canvas-component/symphonies/create.symphony";
 
 describe("canvas-component-create-symphony", () => {
@@ -6,53 +8,20 @@ describe("canvas-component-create-symphony", () => {
       tag: "button",
       text: "Click Me",
       classes: ["rx-comp", "rx-button"],
-      style: { padding: "8px 12px" },
     };
   }
 
-  function makeCtx(withStageCrew = false) {
-    const calls: any[] = [];
-    const stageCrew = withStageCrew
-      ? {
-          beginBeat: (correlationId: string, meta?: any) => {
-            const ops: any[] = [];
-            return {
-              create: (tag: string, opts: { classes?: string[]; attrs?: Record<string, string> }) => {
-                ops.push(["create", tag, opts]);
-                return {
-                  appendTo: (parent: string) => {
-                    ops.push(["appendTo", parent]);
-                    return txn;
-                  },
-                } as any;
-              },
-              update: (selector: string, opts: any) => {
-                ops.push(["update", selector, opts]);
-                return txn;
-              },
-              remove: (selector: string) => {
-                ops.push(["remove", selector]);
-                return txn;
-              },
-              commit: (opts?: any) => {
-                calls.push(["commit", ops, opts]);
-              },
-            } as any;
-            function txn() { /* placeholder chainable */ }
-          },
-        }
-      : undefined;
-
-    return {
-      payload: {},
-      stageCrew,
-      util: { hash: () => "abc123" },
-      calls,
-    } as any;
+  function makeCtx() {
+    return { payload: {} } as any;
   }
 
-  it("resolves template and returns UI payload via notifyUi", () => {
-    const ctx: any = makeCtx(false);
+  beforeEach(() => {
+    // Provide a host container for direct DOM updates
+    document.body.innerHTML = '<div id="rx-canvas"></div>';
+  });
+
+  it("resolves template and returns UI payload via notifyUi (DOM path)", () => {
+    const ctx: any = makeCtx();
     const template = makeTemplate();
 
     handlers.resolveTemplate({ component: { template } } as any, ctx as any);
@@ -68,24 +37,6 @@ describe("canvas-component-create-symphony", () => {
     expect(received.tag).toBe("button");
     expect(received.position).toEqual(pos);
     expect(received.classes).toContain("rx-button");
-  });
-
-  describe("StageCrew transaction path", () => {
-    it("creates, updates and commits a StageCrew transaction", () => {
-      const ctx: any = makeCtx(true);
-      const template = makeTemplate();
-
-      handlers.resolveTemplate({ component: { template } } as any, ctx as any);
-      handlers.createNode({ position: { x: 10, y: 20 } } as any, ctx as any);
-
-      const commitCalls = ctx.calls.filter((c: any[]) => c[0] === "commit");
-      expect(commitCalls.length).toBe(1);
-      const ops = commitCalls[0][1];
-      const opNames = ops.map((o: any[]) => o[0]);
-      expect(opNames).toContain("create");
-      expect(opNames).toContain("appendTo");
-      expect(opNames).toContain("update");
-    });
   });
 });
 

--- a/__tests__/canvas/create-page.dom.spec.ts
+++ b/__tests__/canvas/create-page.dom.spec.ts
@@ -1,8 +1,9 @@
 /* @vitest-environment jsdom */
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { onDropForTest } from "../../plugins/canvas/ui/CanvasPage";
 
-// This ensures Canvas UI does not render nodes; StageCrew/DOM is responsible
+import { onDropForTest } from "../../plugins/canvas/ui/CanvasDrop";
+
+// This ensures Canvas UI does not render nodes; stage-crew/DOM handler is responsible
 
 describe("CanvasPage drop orchestration (no UI node rendering)", () => {
   beforeEach(() => {

--- a/__tests__/canvas/drop.spec.ts
+++ b/__tests__/canvas/drop.spec.ts
@@ -1,11 +1,13 @@
+/* @vitest-environment jsdom */
 import { describe, it, expect, vi } from "vitest";
+
+// Import from CanvasDrop (no React, no conductor hook) to avoid SSR asserts
+import { onDropForTest } from "../../plugins/canvas/ui/CanvasDrop";
 
 // This test enforces that Canvas drop triggers the LibraryComponentPlugin drop symphony
 
 describe("canvas drop triggers library-component drop sequence", () => {
   it("calls conductor.play with LibraryComponentPlugin and library-component-drop-symphony", async () => {
-    const { onDropForTest } = await import("../../plugins/canvas/ui/CanvasPage.tsx");
-
     const calls: any[] = [];
     const conductor = {
       play: vi.fn((pluginId: string, seqId: string) => calls.push([pluginId, seqId])),

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
     "eslint": "^9.33.0",
+    "jsdom": "^26.1.0",
     "typescript": "^5.9.2",
     "vite": "^7.1.3",
     "vitest": "^3.2.4"

--- a/plugins/canvas/ui/CanvasDrop.ts
+++ b/plugins/canvas/ui/CanvasDrop.ts
@@ -1,0 +1,16 @@
+export const LIB_COMP_PLUGIN_ID = "LibraryComponentDropPlugin" as const;
+export const LIB_COMP_DROP_SEQ_ID = "library-component-drop-symphony" as const;
+
+export async function onDropForTest(e: any, conductor: any, onCreated?: (n: any) => void) {
+  e.preventDefault();
+  const raw = e.dataTransfer.getData("application/rx-component");
+  const payload = raw ? JSON.parse(raw) : {};
+  const rect = e.currentTarget.getBoundingClientRect();
+  const position = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  conductor?.play?.(LIB_COMP_PLUGIN_ID, LIB_COMP_DROP_SEQ_ID, {
+    component: payload.component,
+    position,
+    onComponentCreated: onCreated,
+  });
+}
+

--- a/plugins/canvas/ui/CanvasPage.tsx
+++ b/plugins/canvas/ui/CanvasPage.tsx
@@ -1,21 +1,6 @@
 import React from "react";
 import { useConductor } from "../../../src/conductor";
-
-export const LIB_COMP_PLUGIN_ID = "LibraryComponentDropPlugin" as const;
-export const LIB_COMP_DROP_SEQ_ID = "library-component-drop-symphony" as const;
-
-export async function onDropForTest(e: any, conductor: any, onCreated?: (n: any) => void) {
-  e.preventDefault();
-  const raw = e.dataTransfer.getData("application/rx-component");
-  const payload = raw ? JSON.parse(raw) : {};
-  const rect = e.currentTarget.getBoundingClientRect();
-  const position = { x: e.clientX - rect.left, y: e.clientY - rect.top };
-  conductor?.play?.(LIB_COMP_PLUGIN_ID, LIB_COMP_DROP_SEQ_ID, {
-    component: payload.component,
-    position,
-    onComponentCreated: onCreated,
-  });
-}
+import { onDropForTest } from "./CanvasDrop";
 
 export function CanvasPage() {
   const conductor = useConductor();


### PR DESCRIPTION
This PR updates the test suite to align with current behavior and removes reliance on the StageCrew API.

Changes:
- __tests__/canvas-component/create.spec.ts: remove StageCrew txn assertions; use jsdom + #rx-canvas to exercise direct DOM handler
- __tests__/canvas/drop.spec.ts, __tests__/canvas/create-page.dom.spec.ts: import a new non-React helper to avoid SSR-specific errors
- plugins/canvas/ui/CanvasDrop.ts: new helper with onDropForTest extracted from CanvasPage
- plugins/canvas/ui/CanvasPage.tsx: use the helper
- devDeps: add jsdom (installed via npm)

Rationale:
- StageCrew API must no longer be used; direct DOM updates happen in stage-crew handlers
- Tests now validate the existing functionality and run cleanly

Validation:
- npm test → all tests pass locally

Resolves #5

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author