### PR TITLE
chore(#65): Enforce plugin boundary (error) and add Host SDK usage docs

### DIFF
--- a/docs/adr/ADR-0023 — Host SDK and Plugin Decoupling.md
+++ b/docs/adr/ADR-0023 — Host SDK and Plugin Decoupling.md
@@ -90,6 +90,8 @@ After:
 import { useConductor, EventRouter, resolveInteraction } from "@renderx/host-sdk";
 ```
 
+See also: docs/host-sdk/USING_HOST_SDK.md
+
 ## Manifest example (transition to package specifiers)
 
 Before:

--- a/docs/host-sdk/USING_HOST_SDK.md
+++ b/docs/host-sdk/USING_HOST_SDK.md
@@ -1,0 +1,45 @@
+## Using the Host SDK (@renderx/host-sdk)
+
+This guide shows how plugins should interact with the host through the stable SDK instead of importing host internals from src/**.
+
+### Install/resolve
+- In this repo, the SDK is provided as a local workspace package.
+- In external plugin repos, add a dev dependency to @renderx/host-sdk matching the host version.
+
+### Import examples
+```ts
+import { useConductor, EventRouter, resolveInteraction } from "@renderx/host-sdk";
+```
+
+For feature flags:
+```ts
+import { isFlagEnabled, getFlagMeta } from "@renderx/host-sdk";
+```
+
+### Do
+- Publish events and let sequences route via EventRouter:
+```ts
+await EventRouter.publish("canvas.component.drag.move", { id, position }, conductor);
+```
+- Resolve interactions via resolveInteraction and call conductor.play():
+```ts
+const r = resolveInteraction("control.panel.update");
+await conductor.play(r.pluginId, r.sequenceId, payload);
+```
+- Use useConductor() in UI to get the singleton conductor instance.
+
+### Don’t
+- Don’t import from src/** inside plugins/** (enforced by ESLint).
+- Don’t bypass sequencing. Always go through conductor.play() or EventRouter.publish().
+- Don’t manipulate DOM/CSS in UI; do it in stage‑crew handlers.
+
+### PanelSlot module specifiers
+Plugin UIs can be referenced by:
+- Path: "/plugins/…" (transition period)
+- Package name: "@org/plugin"
+- URL: "https://cdn.example.com/plugin.mjs" (browser; Node/test falls back gracefully)
+
+### Troubleshooting
+- ESLint error: "Plugins must not import host internals" → switch to SDK imports.
+- Node/test error when importing https URLs in PanelSlot is expected; tests assert graceful fallback.
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -223,7 +223,7 @@ export default [
       "no-host-internals-in-plugins": noHostInternalsInPlugins,
     },
     rules: {
-      "no-host-internals-in-plugins/no-host-internals-in-plugins": "warn",
+      "no-host-internals-in-plugins/no-host-internals-in-plugins": "error",
       "no-restricted-globals": [
         "error",
         "document",

--- a/packages/host-sdk/index.ts
+++ b/packages/host-sdk/index.ts
@@ -4,4 +4,8 @@ export type { ConductorClient } from "musical-conductor"; // from external lib t
 export { EventRouter } from "../../src/EventRouter";
 export { resolveInteraction } from "../../src/interactionManifest";
 export { isFlagEnabled, getFlagMeta } from "../../src/feature-flags/flags";
-
+export {
+  getTagForType,
+  computeTagFromJson,
+} from "../../src/component-mapper/mapper";
+export { mapJsonComponentToTemplate } from "../../src/jsonComponent.mapper";

--- a/plugins/canvas-component/symphonies/create/create.notify.ts
+++ b/plugins/canvas-component/symphonies/create/create.notify.ts
@@ -1,4 +1,4 @@
-import { EventRouter } from "../../../../src/EventRouter";
+import { EventRouter } from "@renderx/host-sdk";
 
 export const notifyUi = (data: any, ctx: any) => {
   const created = ctx.payload?.createdNode;

--- a/plugins/canvas-component/symphonies/drag/drag.symphony.ts
+++ b/plugins/canvas-component/symphonies/drag/drag.symphony.ts
@@ -1,6 +1,5 @@
 import { updatePosition } from "./drag.stage-crew";
-import { resolveInteraction } from "../../../../src/interactionManifest";
-import { EventRouter } from "../../../../src/EventRouter";
+import { resolveInteraction, EventRouter } from "@renderx/host-sdk";
 
 // NOTE: Runtime sequences are mounted from JSON (see json-sequences/*). This file only exports handlers.
 

--- a/plugins/canvas-component/symphonies/export/export.pure.ts
+++ b/plugins/canvas-component/symphonies/export/export.pure.ts
@@ -1,4 +1,4 @@
-import { getTagForType } from "../../../../src/component-mapper/mapper";
+import { getTagForType } from "@renderx/host-sdk";
 
 export const buildUiFileContent = (data: any, ctx: any) => {
   try {

--- a/plugins/canvas-component/symphonies/resize/resize.move.symphony.ts
+++ b/plugins/canvas-component/symphonies/resize/resize.move.symphony.ts
@@ -1,6 +1,5 @@
 import { updateSize } from "./resize.stage-crew";
-import { resolveInteraction } from "../../../../src/interactionManifest";
-import { EventRouter } from "../../../../src/EventRouter";
+import { resolveInteraction, EventRouter } from "@renderx/host-sdk";
 
 // NOTE: Runtime sequences are mounted from JSON (see json-sequences/*). This file only exports handlers.
 

--- a/plugins/library/symphonies/load.symphony.ts
+++ b/plugins/library/symphonies/load.symphony.ts
@@ -1,5 +1,5 @@
 // NOTE: Runtime sequences are mounted from JSON (see json-sequences/*). This file only exports handlers.
-import { mapJsonComponentToTemplate } from "../../../src/jsonComponent.mapper";
+import { mapJsonComponentToTemplate } from "@renderx/host-sdk";
 import { cssRegistry } from "../../control-panel/state/css-registry.store";
 
 function mapJsonComponentToTemplateCompat(json: any) {


### PR DESCRIPTION
## Summary

ADR-0023 Phase 2: escalate the plugin boundary rule to error and provide a short usage guide for @renderx/host-sdk.

## Changes
- ESLint: `no-host-internals-in-plugins` raised from warn -> error for plugins/**/*
- Docs: `docs/host-sdk/USING_HOST_SDK.md` with import examples, dos/don'ts, PanelSlot specifier notes, troubleshooting
- ADR-0023: link to the new usage doc
- SDK: re-export mapJsonComponentToTemplate, computeTagFromJson, getTagForType to support plugin usage
- Migrations: fixed remaining plugin imports flagged by the rule

## Verification
- `npm test`: all tests passing locally (237/237)
- `npm run lint`: only known layout-style errors from #61 remain; plugin boundary is now enforced as error

Closes #65

---
PR opened by Augment Agent (Augment Code)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author