### PR TITLE
feat(#72): header slots + header plugins (title/controls/theme-toggle)

### DIFF
--- a/__tests__/eslint-rules/stage-crew-deprecation.spec.ts
+++ b/__tests__/eslint-rules/stage-crew-deprecation.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import rule from '../../eslint-rules/deprecate-stagecrew-api.js';
+
+function run(ruleName: string, code: string, filename: string) {
+  const messages: any[] = [];
+  const context: any = {
+    getFilename: vi.fn(() => filename),
+    report: vi.fn((msg) => messages.push(msg)),
+    sourceCode: { getText: (n: any) => n && n.name ? n.name : '' },
+  };
+  const visitor = (rule as any).rules[ruleName].create(context);
+  const ast = {} as any; // We don't parse; our rule visits via Program and does simple text checks
+  visitor.Program?.(ast);
+  return messages;
+}
+
+describe('deprecate-stagecrew-api ESLint rule', () => {
+  it('reports usage of ctx.stageCrew.beginBeat() in stage-crew files', () => {
+    const code = `export function demo(data:any, ctx:any){ const txn = ctx.stageCrew.beginBeat(); txn.commit(); }`;
+    const msgs = run('no-stagecrew-api-in-stage-crew', code, '__tests__/fixtures/lint/uses-stagecrew.stage-crew.ts');
+    expect(msgs.some(m => m.messageId === 'deprecatedStageCrew')).toBe(true);
+  });
+
+  it('does not report in non-stage-crew files', () => {
+    const code = `export function pure(data:any, ctx:any){ return data }`;
+    const msgs = run('no-stagecrew-api-in-stage-crew', code, '__tests__/fixtures/lint/no-stagecrew.pure.ts');
+    expect(msgs.length).toBe(0);
+  });
+});
+

--- a/__tests__/fixtures/lint/no-stagecrew.pure.ts
+++ b/__tests__/fixtures/lint/no-stagecrew.pure.ts
@@ -1,0 +1,5 @@
+export function pure(data: any, ctx: any) {
+  // no stageCrew usage here
+  return data;
+}
+

--- a/__tests__/fixtures/lint/uses-stagecrew.stage-crew.ts
+++ b/__tests__/fixtures/lint/uses-stagecrew.stage-crew.ts
@@ -1,0 +1,5 @@
+export function demo(data: any, ctx: any) {
+  const txn = ctx.stageCrew.beginBeat();
+  txn.commit();
+}
+

--- a/__tests__/layout/layout-engine.header.manifest.spec.tsx
+++ b/__tests__/layout/layout-engine.header.manifest.spec.tsx
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createRoot } from "react-dom/client";
+
+// Stub PanelSlot to avoid plugin-manifest dependency in this unit test
+vi.mock("../../src/components/PanelSlot", () => ({
+  PanelSlot: (props: any) =>
+    React.createElement("div", { "data-panel-slot": props.slot }),
+}));
+
+function mockFetchLayoutManifestWithHeader() {
+  const manifest = {
+    version: "1.0.0",
+    layout: {
+      kind: "grid",
+      columns: ["320px", "1fr", "360px"],
+      rows: ["48px", "1fr"],
+      areas: [
+        ["headerLeft", "headerCenter", "headerRight"],
+        ["library", "canvas", "controlPanel"],
+      ],
+      gap: { column: "0", row: "0" },
+    },
+    slots: [
+      { name: "headerLeft", constraints: { minHeight: 40 } },
+      { name: "headerCenter", constraints: { minHeight: 40 } },
+      { name: "headerRight", constraints: { minHeight: 40 } },
+      { name: "library", constraints: { minWidth: 280 } },
+      { name: "canvas", constraints: { minWidth: 480 } },
+      { name: "controlPanel", constraints: { minWidth: 320 } },
+    ],
+  };
+  vi.spyOn(globalThis, "fetch").mockImplementation((input: any) => {
+    const url = String(input || "");
+    if (url.endsWith("/layout-manifest.json")) {
+      return Promise.resolve(
+        new Response(JSON.stringify(manifest), { status: 200 })
+      ) as any;
+    }
+    return Promise.resolve(new Response("not found", { status: 404 })) as any;
+  });
+}
+
+describe("LayoutEngine default manifest includes header row with three slots (TDD)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders 6 slot wrappers including headerLeft/Center/Right", async () => {
+    // Ensure fresh module state and stub fetch for this test
+    vi.resetModules();
+    mockFetchLayoutManifestWithHeader();
+
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const root = createRoot(el);
+
+    const { LayoutEngine } = await import("../../src/layout/LayoutEngine");
+
+    // Act: render the engine
+    root.render(React.createElement(LayoutEngine));
+
+    // Poll until rendered or timeout
+    const tryFind = () => Array.from(document.querySelectorAll("[data-slot]"));
+    for (let i = 0; i < 20 && tryFind().length < 6; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    const wrappers = tryFind();
+    const names = wrappers.map((el) => el.getAttribute("data-slot"));
+
+    expect(wrappers.length).toBe(6);
+    expect(names).toContain("headerLeft");
+    expect(names).toContain("headerCenter");
+    expect(names).toContain("headerRight");
+    expect(names).toContain("library");
+    expect(names).toContain("canvas");
+    expect(names).toContain("controlPanel");
+  });
+});

--- a/docs/prototypes/dark-mode-example.html
+++ b/docs/prototypes/dark-mode-example.html
@@ -1,0 +1,702 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>RenderX Component Library - Dark Mode</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #0a0a0b;
+            color: #f8fafc;
+            height: 100vh;
+            overflow: hidden;
+        }
+        
+        .app-container {
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+            background: #0a0a0b;
+        }
+        
+        /* Top Navigation Bar */
+        .top-nav {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 8px 16px;
+            background: linear-gradient(135deg, #1e1e2e, #2a2a3a);
+            border-bottom: 1px solid #333344;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        }
+        
+        .app-title {
+            font-size: 16px;
+            font-weight: 600;
+            color: #f8fafc;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .nav-actions {
+            display: flex;
+            gap: 8px;
+        }
+        
+        .nav-btn {
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            color: #cbd5e1;
+            padding: 6px 12px;
+            border-radius: 6px;
+            font-size: 12px;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        
+        .nav-btn:hover {
+            background: rgba(255, 255, 255, 0.1);
+            border-color: rgba(255, 255, 255, 0.2);
+            color: #f8fafc;
+        }
+        
+        .theme-toggle {
+            background: #fbbf24;
+            color: #1f2937;
+            border-color: #f59e0b;
+        }
+        
+        .theme-toggle:hover {
+            background: #f59e0b;
+        }
+        
+        /* Main Content Area */
+        .main-content {
+            flex: 1;
+            display: flex;
+            overflow: hidden;
+        }
+        
+        /* Component Library Sidebar */
+        .component-library {
+            width: 320px;
+            background: linear-gradient(180deg, #6366f1, #4f46e5);
+            display: flex;
+            flex-direction: column;
+            border-right: 1px solid #444455;
+            box-shadow: 2px 0 12px rgba(0, 0, 0, 0.2);
+        }
+        
+        .library-header {
+            padding: 20px;
+            text-align: center;
+            background: rgba(0, 0, 0, 0.2);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        
+        .library-title {
+            font-size: 18px;
+            font-weight: 700;
+            color: white;
+            margin-bottom: 4px;
+        }
+        
+        .library-subtitle {
+            font-size: 12px;
+            color: rgba(255, 255, 255, 0.8);
+        }
+        
+        .library-content {
+            flex: 1;
+            padding: 20px;
+            overflow-y: auto;
+        }
+        
+        .library-content::-webkit-scrollbar {
+            width: 6px;
+        }
+        
+        .library-content::-webkit-scrollbar-track {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 3px;
+        }
+        
+        .library-content::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 3px;
+        }
+        
+        .component-category {
+            margin-bottom: 32px;
+        }
+        
+        .category-title {
+            font-size: 11px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.9);
+            margin-bottom: 16px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        
+        .component-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 12px;
+        }
+        
+        .component-item {
+            background: rgba(255, 255, 255, 0.1);
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 12px;
+            padding: 16px;
+            cursor: grab;
+            transition: all 0.3s ease;
+            text-align: center;
+        }
+        
+        .component-item:hover {
+            background: rgba(255, 255, 255, 0.15);
+            border-color: rgba(255, 255, 255, 0.3);
+            transform: translateY(-2px);
+            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
+        }
+        
+        .component-icon {
+            font-size: 24px;
+            margin-bottom: 8px;
+            display: block;
+        }
+        
+        .component-name {
+            font-size: 13px;
+            font-weight: 600;
+            color: white;
+            margin-bottom: 4px;
+        }
+        
+        .component-description {
+            font-size: 10px;
+            color: rgba(255, 255, 255, 0.7);
+            line-height: 1.4;
+        }
+        
+        /* Canvas Area */
+        .canvas-container {
+            flex: 1;
+            background: #111827;
+            display: flex;
+            flex-direction: column;
+            position: relative;
+        }
+        
+        .canvas-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 12px 20px;
+            background: #1f2937;
+            border-bottom: 1px solid #374151;
+        }
+        
+        .canvas-title {
+            font-size: 16px;
+            font-weight: 600;
+            color: #f9fafb;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .canvas-controls {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        .canvas-tool {
+            background: #374151;
+            border: 1px solid #4b5563;
+            color: #d1d5db;
+            padding: 8px;
+            border-radius: 6px;
+            cursor: pointer;
+            transition: all 0.2s;
+            font-size: 16px;
+            width: 36px;
+            height: 36px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        
+        .canvas-tool:hover {
+            background: #4b5563;
+            color: #f9fafb;
+        }
+        
+        .canvas-tool.active {
+            background: #3b82f6;
+            border-color: #2563eb;
+            color: white;
+        }
+        
+        .tool-divider {
+            width: 1px;
+            height: 24px;
+            background: #4b5563;
+            margin: 0 4px;
+        }
+        
+        .zoom-controls {
+            display: flex;
+            align-items: center;
+            background: #374151;
+            border: 1px solid #4b5563;
+            border-radius: 6px;
+            padding: 4px;
+            gap: 4px;
+        }
+        
+        .zoom-btn {
+            background: none;
+            border: none;
+            color: #d1d5db;
+            padding: 4px 8px;
+            cursor: pointer;
+            border-radius: 4px;
+            font-size: 14px;
+            font-weight: 600;
+        }
+        
+        .zoom-btn:hover {
+            background: #4b5563;
+            color: #f9fafb;
+        }
+        
+        .zoom-level {
+            font-size: 11px;
+            color: #9ca3af;
+            min-width: 40px;
+            text-align: center;
+            font-family: 'SF Mono', monospace;
+        }
+        
+        .canvas-content {
+            flex: 1;
+            background: #0f172a;
+            background-image: 
+                radial-gradient(circle at 20px 20px, #1e293b 1px, transparent 1px);
+            background-size: 20px 20px;
+            position: relative;
+            overflow: auto;
+        }
+        
+        /* Properties Panel */
+        .properties-panel {
+            width: 320px;
+            background: linear-gradient(180deg, #8b5cf6, #7c3aed);
+            display: flex;
+            flex-direction: column;
+            border-left: 1px solid #444455;
+            box-shadow: -2px 0 12px rgba(0, 0, 0, 0.2);
+        }
+        
+        .properties-header {
+            padding: 20px;
+            text-align: center;
+            background: rgba(0, 0, 0, 0.2);
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        
+        .properties-title {
+            font-size: 16px;
+            font-weight: 600;
+            color: white;
+            margin-bottom: 8px;
+        }
+        
+        .properties-content {
+            flex: 1;
+            padding: 24px;
+            overflow-y: auto;
+        }
+        
+        .properties-content::-webkit-scrollbar {
+            width: 6px;
+        }
+        
+        .properties-content::-webkit-scrollbar-track {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 3px;
+        }
+        
+        .properties-content::-webkit-scrollbar-thumb {
+            background: rgba(255, 255, 255, 0.3);
+            border-radius: 3px;
+        }
+        
+        .no-selection {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 200px;
+            text-align: center;
+            color: rgba(255, 255, 255, 0.7);
+        }
+        
+        .no-selection-icon {
+            font-size: 48px;
+            margin-bottom: 16px;
+            opacity: 0.6;
+            filter: grayscale(1);
+        }
+        
+        .no-selection h4 {
+            font-size: 16px;
+            font-weight: 600;
+            margin: 0 0 8px 0;
+            color: rgba(255, 255, 255, 0.9);
+        }
+        
+        .no-selection p {
+            font-size: 13px;
+            margin: 0;
+            line-height: 1.5;
+            color: rgba(255, 255, 255, 0.6);
+        }
+        
+        /* Dark mode specific enhancements */
+        .glow-effect {
+            position: relative;
+        }
+        
+        .glow-effect::before {
+            content: '';
+            position: absolute;
+            top: -2px;
+            left: -2px;
+            right: -2px;
+            bottom: -2px;
+            background: linear-gradient(45deg, #6366f1, #8b5cf6, #06b6d4, #10b981);
+            border-radius: inherit;
+            z-index: -1;
+            opacity: 0;
+            transition: opacity 0.3s;
+        }
+        
+        .glow-effect:hover::before {
+            opacity: 0.3;
+        }
+        
+        /* Animated background for canvas */
+        .canvas-content::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: 
+                radial-gradient(circle at 25% 25%, rgba(59, 130, 246, 0.1) 0%, transparent 50%),
+                radial-gradient(circle at 75% 75%, rgba(139, 92, 246, 0.1) 0%, transparent 50%);
+            pointer-events: none;
+            opacity: 0.5;
+        }
+        
+        /* Subtle animations */
+        .component-item {
+            animation: float 6s ease-in-out infinite;
+        }
+        
+        .component-item:nth-child(2n) {
+            animation-delay: -3s;
+        }
+        
+        @keyframes float {
+            0%, 100% { transform: translateY(0px); }
+            50% { transform: translateY(-2px); }
+        }
+        
+        /* Glass morphism effects */
+        .glass-panel {
+            background: rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(20px);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+        }
+        
+        /* Responsive design */
+        @media (max-width: 1200px) {
+            .component-library,
+            .properties-panel {
+                width: 280px;
+            }
+        }
+        
+        @media (max-width: 768px) {
+            .main-content {
+                flex-direction: column;
+            }
+            
+            .component-library,
+            .properties-panel {
+                width: 100%;
+                max-height: 200px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="app-container">
+        <!-- Top Navigation -->
+        <div class="top-nav">
+            <div class="app-title">
+                <span>🔧</span>
+                RenderX Plugins Demo
+            </div>
+            <div class="nav-actions">
+                <button class="nav-btn">New</button>
+                <button class="nav-btn">Open</button>
+                <button class="nav-btn">Save</button>
+                <button class="nav-btn theme-toggle">☀️ Light</button>
+            </div>
+        </div>
+        
+        <!-- Main Content -->
+        <div class="main-content">
+            <!-- Component Library -->
+            <div class="component-library">
+                <div class="library-header">
+                    <div class="library-title">🧩 Component Library</div>
+                    <div class="library-subtitle">Drag components to the canvas</div>
+                </div>
+                
+                <div class="library-content">
+                    <div class="component-category">
+                        <div class="category-title">Basic Components</div>
+                        <div class="component-grid">
+                            <div class="component-item glow-effect" draggable="true">
+                                <div class="component-icon">⭕</div>
+                                <div class="component-name">Button</div>
+                                <div class="component-description">Interactive button component with click handling - JSON replacement for built-in button</div>
+                            </div>
+                            
+                            <div class="component-item glow-effect" draggable="true">
+                                <div class="component-icon">📄</div>
+                                <div class="component-name">Input</div>
+                                <div class="component-description">Text input component with validation and focus handling - JSON replacement for built-in input</div>
+                            </div>
+                            
+                            <div class="component-item glow-effect" draggable="true">
+                                <div class="component-icon">📏</div>
+                                <div class="component-name">Line</div>
+                                <div class="component-description">Line component rendered via CSS variables controlling endpoints/angle/length</div>
+                            </div>
+                            
+                            <div class="component-item glow-effect" draggable="true">
+                                <div class="component-icon">📄</div>
+                                <div class="component-name">Heading</div>
+                                <div class="component-description">Heading component with multiple levels and typography controls - JSON replacement for built-in heading</div>
+                            </div>
+                            
+                            <div class="component-item glow-effect" draggable="true">
+                                <div class="component-icon">🖼️</div>
+                                <div class="component-name">Image</div>
+                                <div class="component-description">Image component with src, alt text, and aspect ratio controls - JSON replacement for built-in image</div>
+                            </div>
+                            
+                            <div class="component-item glow-effect" draggable="true">
+                                <div class="component-icon">📄</div>
+                                <div class="component-name">Paragraph</div>
+                                <div class="component-description">Paragraph component with rich text content and formatting options - JSON replacement for built-in paragraph</div>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="component-category">
+                        <div class="category-title">Layout Components</div>
+                        <div class="component-grid">
+                            <div class="component-item glow-effect" draggable="true">
+                                <div class="component-icon">📦</div>
+                                <div class="component-name">Container</div>
+                                <div class="component-description">Container that can hold child components and provides relative positioning context</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Canvas Area -->
+            <div class="canvas-container">
+                <div class="canvas-header">
+                    <div class="canvas-title">
+                        <span>🎯</span>
+                        Design Canvas
+                    </div>
+                    <div class="canvas-controls">
+                        <div class="canvas-tool active" title="Select Tool">
+                            <span>🔍</span>
+                        </div>
+                        <div class="canvas-tool" title="Lock Tool">
+                            <span>🔒</span>
+                        </div>
+                        <div class="canvas-tool" title="Edit Tool">
+                            <span>✏️</span>
+                        </div>
+                        <div class="canvas-tool" title="Rectangle Tool">
+                            <span>⬛</span>
+                        </div>
+                        <div class="canvas-tool" title="Folder Tool">
+                            <span>📁</span>
+                        </div>
+                        
+                        <div class="tool-divider"></div>
+                        
+                        <div class="zoom-controls">
+                            <button class="zoom-btn">−</button>
+                            <span class="zoom-level">100%</span>
+                            <button class="zoom-btn">+</button>
+                        </div>
+                        
+                        <div class="canvas-tool" title="Preview Mode">
+                            <span>👁️</span>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="canvas-content">
+                    <!-- Canvas content will be rendered here -->
+                </div>
+            </div>
+            
+            <!-- Properties Panel -->
+            <div class="properties-panel">
+                <div class="properties-header">
+                    <div class="properties-title">⚙️ Properties Panel</div>
+                </div>
+                
+                <div class="properties-content">
+                    <div class="no-selection glass-panel" style="border-radius: 12px; padding: 32px;">
+                        <div class="no-selection-icon">🎯</div>
+                        <h4>No Element Selected</h4>
+                        <p>Click on a component in the canvas to edit its properties and styling options.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <script>
+        // Add interactivity for demo purposes
+        document.querySelectorAll('.canvas-tool').forEach(tool => {
+            tool.addEventListener('click', () => {
+                document.querySelectorAll('.canvas-tool').forEach(t => t.classList.remove('active'));
+                tool.classList.add('active');
+            });
+        });
+        
+        // Zoom functionality
+        let zoomLevel = 100;
+        const zoomDisplay = document.querySelector('.zoom-level');
+        const zoomIn = document.querySelectorAll('.zoom-btn')[1];
+        const zoomOut = document.querySelectorAll('.zoom-btn')[0];
+        
+        zoomIn.addEventListener('click', () => {
+            zoomLevel = Math.min(200, zoomLevel + 10);
+            zoomDisplay.textContent = zoomLevel + '%';
+        });
+        
+        zoomOut.addEventListener('click', () => {
+            zoomLevel = Math.max(25, zoomLevel - 10);
+            zoomDisplay.textContent = zoomLevel + '%';
+        });
+        
+        // Theme toggle (placeholder)
+        document.querySelector('.theme-toggle').addEventListener('click', () => {
+            alert('Theme toggle functionality would switch to light mode here!');
+        });
+        
+        // Component drag simulation
+        document.querySelectorAll('.component-item').forEach(item => {
+            item.addEventListener('dragstart', (e) => {
+                e.dataTransfer.setData('text/plain', item.querySelector('.component-name').textContent);
+            });
+        });
+        
+        // Canvas drop simulation
+        const canvas = document.querySelector('.canvas-content');
+        canvas.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            canvas.style.backgroundColor = 'rgba(59, 130, 246, 0.1)';
+        });
+        
+        canvas.addEventListener('dragleave', () => {
+            canvas.style.backgroundColor = '';
+        });
+        
+        canvas.addEventListener('drop', (e) => {
+            e.preventDefault();
+            canvas.style.backgroundColor = '';
+            
+            const componentName = e.dataTransfer.getData('text/plain');
+            const rect = canvas.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            
+            // Create dropped component element
+            const component = document.createElement('div');
+            component.style.cssText = `
+                position: absolute;
+                left: ${x}px;
+                top: ${y}px;
+                background: rgba(59, 130, 246, 0.2);
+                border: 2px solid #3b82f6;
+                border-radius: 8px;
+                padding: 12px 16px;
+                color: #60a5fa;
+                font-weight: 500;
+                cursor: move;
+                backdrop-filter: blur(10px);
+            `;
+            component.textContent = componentName;
+            canvas.appendChild(component);
+            
+            // Make it draggable within canvas
+            let isDragging = false;
+            let offsetX, offsetY;
+            
+            component.addEventListener('mousedown', (e) => {
+                isDragging = true;
+                offsetX = e.clientX - component.offsetLeft;
+                offsetY = e.clientY - component.offsetTop;
+                component.style.zIndex = '1000';
+            });
+            
+            document.addEventListener('mousemove', (e) => {
+                if (isDragging) {
+                    component.style.left = (e.clientX - offsetX) + 'px';
+                    component.style.top = (e.clientY - offsetY) + 'px';
+                }
+            });
+            
+            document.addEventListener('mouseup', () => {
+                if (isDragging) {
+                    isDragging = false;
+                    component.style.zIndex = 'auto';
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/eslint-rules/deprecate-stagecrew-api.js
+++ b/eslint-rules/deprecate-stagecrew-api.js
@@ -1,0 +1,76 @@
+/**
+ * ESLint plugin: deprecate-stagecrew-api
+ * - no-stagecrew-api-in-stage-crew: Forbid usage of ctx.stageCrew (conductor StageCrew API)
+ *   inside stage-crew handlers. Handlers must manipulate the DOM directly instead.
+ */
+import fs from "node:fs";
+
+function isStageCrewFile(filename) {
+  const f = String(filename || "");
+  // Match *.stage-crew.ts or *.stage-crew.tsx anywhere in path
+  return /\.stage-crew\.(t|j)sx?$/.test(f);
+}
+
+function getSourceText(context) {
+  try {
+    const sc = context.getSourceCode?.();
+    if (sc?.text && typeof sc.text === "string") return String(sc.text);
+  } catch {}
+  try {
+    const filename = context.getFilename?.();
+    if (filename && fs.existsSync(filename)) {
+      return fs.readFileSync(filename, "utf8");
+    }
+  } catch {}
+  return "";
+}
+
+const noStageCrewInStageCrewRule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow StageCrew API (ctx.stageCrew / beginBeat / injectRawCSS) in stage-crew handlers",
+    },
+    schema: [],
+    messages: {
+      deprecatedStageCrew:
+        "StageCrew API is deprecated in stage-crew handlers. Manipulate the DOM directly instead (found '{{usage}}').",
+    },
+  },
+  create(context) {
+    const filename = context.getFilename?.() || "";
+    if (!isStageCrewFile(filename)) return {};
+
+    return {
+      Program(node) {
+        const text = getSourceText(context);
+        if (!text) return;
+
+        // Minimal patterns indicating use of the deprecated API
+        const patterns = [
+          /\bctx\s*\.\s*stageCrew\b/, // ctx.stageCrew
+          /\bstageCrew\s*[\.?]\s*beginBeat\b/, // stageCrew.beginBeat or stageCrew?.beginBeat
+          /\bstageCrew\s*[\.?]\s*injectRawCSS\b/,
+          /\bstageCrew\s*[\.?]\s*injectInstanceCSS\b/,
+        ];
+
+        for (const re of patterns) {
+          const m = text.match(re);
+          if (m) {
+            context.report({ node, messageId: "deprecatedStageCrew", data: { usage: m[0] } });
+            // Report once per file for now to keep noise low
+            break;
+          }
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    "no-stagecrew-api-in-stage-crew": noStageCrewInStageCrewRule,
+  },
+};
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ import requireSlotManifestRegistration from "./eslint-rules/require-slot-manifes
 import noLayoutLogicInComponents from "./eslint-rules/no-layout-logic-in-components.js";
 import requireManifestValidation from "./eslint-rules/require-manifest-validation.js";
 import noHostInternalsInPlugins from "./eslint-rules/no-host-internals-in-plugins.js";
+import deprecateStageCrew from "./eslint-rules/deprecate-stagecrew-api.js";
 
 export default [
   {
@@ -59,6 +60,7 @@ export default [
       "layout-logic": noLayoutLogicInComponents,
       "layout-manifest-validation": requireManifestValidation,
       "no-host-internals-in-plugins": noHostInternalsInPlugins,
+      "deprecate-stagecrew-api": deprecateStageCrew,
     },
     rules: {
       "play-routing/no-hardcoded-play-ids": "error",
@@ -104,6 +106,10 @@ export default [
   // UI code: forbid DOM & StageCrew/EventBus
   {
     files: ["plugins/**/ui/**/*.{ts,tsx,js,jsx}"],
+    ignores: [
+      // Allow stage-crew handlers in symphonies to live under a ui/ folder
+      "plugins/**/ui/**/*.stage-crew.{ts,tsx}",
+    ],
     rules: {
       "no-restricted-globals": [
         "error",
@@ -338,9 +344,14 @@ export default [
   // Stage-crew handlers: allow DOM, forbid UI imports, forbid IO/API here
   {
     files: ["plugins/**/*.{stage-crew}.ts", "plugins/**/*.{stage-crew}.tsx"],
+    plugins: {
+      "deprecate-stagecrew-api": deprecateStageCrew,
+    },
     rules: {
       // Explicitly allow DOM in stage-crew handlers by disabling the global restriction
       "no-restricted-globals": "off",
+      // Enforce deprecation of conductor StageCrew API in stage-crew handlers
+      "deprecate-stagecrew-api/no-stagecrew-api-in-stage-crew": "error",
       // Keep stage-crew clean of UI/IO/API layers
       "no-restricted-imports": [
         "error",

--- a/interaction-manifest.json
+++ b/interaction-manifest.json
@@ -101,6 +101,10 @@
       "pluginId": "ControlPanelPlugin",
       "sequenceId": "control-panel-ui-section-toggle-symphony"
     },
+    "app.ui.theme.toggle": {
+      "pluginId": "HeaderThemePlugin",
+      "sequenceId": "header-ui-theme-toggle-symphony"
+    },
     "library.component.drag.start": {
       "pluginId": "LibraryComponentPlugin",
       "sequenceId": "library-component-drag-symphony"

--- a/json-interactions/header.json
+++ b/json-interactions/header.json
@@ -1,0 +1,10 @@
+{
+  "plugin": "HeaderThemePlugin",
+  "routes": {
+    "app.ui.theme.toggle": {
+      "pluginId": "HeaderThemePlugin",
+      "sequenceId": "header-ui-theme-toggle-symphony"
+    }
+  }
+}
+

--- a/json-sequences/header/index.json
+++ b/json-sequences/header/index.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "sequences": [
+    {
+      "file": "ui.theme.toggle.json",
+      "handlersPath": "/plugins/header/symphonies/ui/ui.symphony.ts"
+    }
+  ]
+}
+

--- a/json-sequences/header/ui.theme.toggle.json
+++ b/json-sequences/header/ui.theme.toggle.json
@@ -1,0 +1,23 @@
+{
+  "pluginId": "HeaderThemePlugin",
+  "id": "header-ui-theme-toggle-symphony",
+  "name": "Header UI Theme Toggle",
+  "movements": [
+    {
+      "id": "toggle",
+      "name": "Toggle Theme",
+      "beats": [
+        {
+          "beat": 1,
+          "event": "app:ui:theme:toggle",
+          "title": "Toggle Theme",
+          "dynamics": "mf",
+          "handler": "toggleTheme",
+          "timing": "immediate",
+          "kind": "stage-crew"
+        }
+      ]
+    }
+  ]
+}
+

--- a/plugins/control-panel/ui/ControlPanel.css
+++ b/plugins/control-panel/ui/ControlPanel.css
@@ -2,12 +2,12 @@
 
 .control-panel {
   width: 100%;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--panel-bg);
   backdrop-filter: blur(10px);
-  border-left: 1px solid #e5e7eb;
+  border-left: 1px solid var(--panel-border);
   display: flex;
   flex-direction: column;
-  box-shadow: -2px 0 20px rgba(0, 0, 0, 0.05);
+  box-shadow: -2px 0 20px var(--panel-shadow);
   height: 100%;
 }
 

--- a/plugins/header/index.ts
+++ b/plugins/header/index.ts
@@ -1,0 +1,9 @@
+export { HeaderTitle } from "./ui/HeaderTitle";
+export { HeaderControls } from "./ui/HeaderControls";
+export { HeaderThemeToggle } from "./ui/HeaderThemeToggle";
+
+// Sequences not needed; registration no-op for now
+export async function register(_conductor: any) {
+  // no-op
+}
+

--- a/plugins/header/symphonies/ui/ui.stage-crew.ts
+++ b/plugins/header/symphonies/ui/ui.stage-crew.ts
@@ -20,7 +20,11 @@ export function toggleTheme(data: any, ctx: any) {
     try {
       ctx.payload.theme = next;
     } catch {}
+
+    // Return the updated theme for DataBaton tracking
+    return { theme: next };
   } catch (e) {
     ctx.logger?.warn?.("toggleTheme failed", e);
+    return { error: e };
   }
 }

--- a/plugins/header/symphonies/ui/ui.stage-crew.ts
+++ b/plugins/header/symphonies/ui/ui.stage-crew.ts
@@ -1,0 +1,20 @@
+export function toggleTheme(data: any, ctx: any) {
+  try {
+    const htmlSelector = "html";
+    const next = data?.theme || "light";
+
+    // Use stage-crew to set attribute; avoid direct DOM writes in UI layer
+    const txn = ctx.stageCrew?.beginBeat?.();
+    if (txn) {
+      txn.update(htmlSelector, { attrs: { "data-theme": next } });
+      txn.commit({ batch: true });
+    }
+
+    // Persist preference marker on ctx (no direct globals)
+    try {
+      ctx.payload.theme = next;
+    } catch {}
+  } catch (e) {
+    ctx.logger?.warn?.("toggleTheme failed", e);
+  }
+}

--- a/plugins/header/symphonies/ui/ui.stage-crew.ts
+++ b/plugins/header/symphonies/ui/ui.stage-crew.ts
@@ -1,14 +1,20 @@
 export function toggleTheme(data: any, ctx: any) {
   try {
-    const htmlSelector = "html";
     const next = data?.theme || "light";
 
-    // Use stage-crew to set attribute; avoid direct DOM writes in UI layer
-    const txn = ctx.stageCrew?.beginBeat?.();
-    if (txn) {
-      txn.update(htmlSelector, { attrs: { "data-theme": next } });
-      txn.commit({ batch: true });
-    }
+    // Direct DOM manipulation in stage-crew handler (StageCrew API deprecated)
+    try {
+      if (typeof document !== "undefined") {
+        const el = document.documentElement;
+        const raf =
+          (typeof window !== "undefined" &&
+            (window as any).requestAnimationFrame) ||
+          null;
+        const apply = () => el.setAttribute("data-theme", next);
+        if (raf) raf(() => apply());
+        else apply();
+      }
+    } catch {}
 
     // Persist preference marker on ctx (no direct globals)
     try {

--- a/plugins/header/symphonies/ui/ui.symphony.ts
+++ b/plugins/header/symphonies/ui/ui.symphony.ts
@@ -1,0 +1,6 @@
+import { toggleTheme } from "./ui.stage-crew";
+
+export const handlers = {
+  toggleTheme,
+};
+

--- a/plugins/header/ui/HeaderControls.tsx
+++ b/plugins/header/ui/HeaderControls.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export function HeaderControls() {
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100%", gap: 8 }}>
+      <button style={{ padding: "6px 10px", fontSize: 12 }} title="New">New</button>
+      <button style={{ padding: "6px 10px", fontSize: 12 }} title="Open">Open</button>
+      <button style={{ padding: "6px 10px", fontSize: 12 }} title="Save">Save</button>
+    </div>
+  );
+}
+

--- a/plugins/header/ui/HeaderThemeToggle.tsx
+++ b/plugins/header/ui/HeaderThemeToggle.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useConductor, resolveInteraction } from "@renderx/host-sdk";
+
+export function HeaderThemeToggle() {
+  const conductor = useConductor();
+  const [theme, setThemeState] = React.useState<"light" | "dark">("light");
+
+  const toggle = async () => {
+    try {
+      const next = theme === "light" ? "dark" : "light";
+      const route = resolveInteraction("app.ui.theme.toggle");
+      await conductor.play(route.pluginId, route.sequenceId, { theme: next });
+      // Optimistically flip local label; actual DOM write happens in stage-crew handler
+      setThemeState(next);
+    } catch (e) {
+      console.warn("Theme toggle failed: ", e);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "flex-end",
+        height: "100%",
+        padding: "0 12px",
+      }}
+    >
+      <button
+        onClick={toggle}
+        style={{ padding: "6px 10px", fontSize: 12 }}
+        title="Toggle Theme"
+      >
+        {theme === "light" ? "🌞 Light" : "🌙 Dark"}
+      </button>
+    </div>
+  );
+}

--- a/plugins/header/ui/HeaderTitle.tsx
+++ b/plugins/header/ui/HeaderTitle.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function HeaderTitle() {
+  return (
+    <div style={{ display: "flex", alignItems: "center", height: "100%", padding: "0 12px", gap: 8 }}>
+      <span style={{ fontSize: 14, fontWeight: 600 }}>RenderX Plugins Demo</span>
+    </div>
+  );
+}
+

--- a/plugins/library/ui/LibraryPanel.css
+++ b/plugins/library/ui/LibraryPanel.css
@@ -2,12 +2,12 @@
 
 .library-sidebar {
   width: 320px;
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--panel-bg);
   backdrop-filter: blur(10px);
-  border-right: 1px solid rgba(0, 0, 0, 0.1);
+  border-right: 1px solid var(--panel-border);
   display: flex;
   flex-direction: column;
-  box-shadow: 2px 0 20px rgba(0, 0, 0, 0.1);
+  box-shadow: 2px 0 20px var(--panel-shadow);
   height: 100%;
 }
 

--- a/public/interaction-manifest.json
+++ b/public/interaction-manifest.json
@@ -101,6 +101,10 @@
       "pluginId": "ControlPanelPlugin",
       "sequenceId": "control-panel-ui-section-toggle-symphony"
     },
+    "app.ui.theme.toggle": {
+      "pluginId": "HeaderThemePlugin",
+      "sequenceId": "header-ui-theme-toggle-symphony"
+    },
     "library.component.drag.start": {
       "pluginId": "LibraryComponentPlugin",
       "sequenceId": "library-component-drag-symphony"

--- a/public/json-sequences/header/index.json
+++ b/public/json-sequences/header/index.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "sequences": [
+    {
+      "file": "ui.theme.toggle.json",
+      "handlersPath": "/plugins/header/symphonies/ui/ui.symphony.ts"
+    }
+  ]
+}
+

--- a/public/json-sequences/header/ui.theme.toggle.json
+++ b/public/json-sequences/header/ui.theme.toggle.json
@@ -1,0 +1,23 @@
+{
+  "pluginId": "HeaderThemePlugin",
+  "id": "header-ui-theme-toggle-symphony",
+  "name": "Header UI Theme Toggle",
+  "movements": [
+    {
+      "id": "toggle",
+      "name": "Toggle Theme",
+      "beats": [
+        {
+          "beat": 1,
+          "event": "app:ui:theme:toggle",
+          "title": "Toggle Theme",
+          "dynamics": "mf",
+          "handler": "toggleTheme",
+          "timing": "immediate",
+          "kind": "stage-crew"
+        }
+      ]
+    }
+  ]
+}
+

--- a/public/layout-manifest.json
+++ b/public/layout-manifest.json
@@ -3,11 +3,17 @@
   "layout": {
     "kind": "grid",
     "columns": ["320px", "1fr", "360px"],
-    "rows": ["1fr"],
-    "areas": [["library", "canvas", "controlPanel"]],
+    "rows": ["48px", "1fr"],
+    "areas": [
+      ["headerLeft", "headerCenter", "headerRight"],
+      ["library", "canvas", "controlPanel"]
+    ],
     "gap": { "column": "0", "row": "0" }
   },
   "slots": [
+    { "name": "headerLeft", "constraints": { "minHeight": 40 } },
+    { "name": "headerCenter", "constraints": { "minHeight": 40 } },
+    { "name": "headerRight", "constraints": { "minHeight": 40 } },
     { "name": "library", "constraints": { "minWidth": 280 } },
     {
       "name": "canvas",

--- a/public/plugins/plugin-manifest.json
+++ b/public/plugins/plugin-manifest.json
@@ -1,8 +1,52 @@
 {
   "plugins": [
-    { "id": "LibraryPlugin",      "ui": { "slot": "library",      "module": "/plugins/library/index.ts",      "export": "LibraryPanel" } },
-    { "id": "CanvasPlugin",       "ui": { "slot": "canvas",       "module": "/plugins/canvas/index.ts",       "export": "CanvasPage" } },
-    { "id": "ControlPanelPlugin", "ui": { "slot": "controlPanel", "module": "/plugins/control-panel/index.ts", "export": "ControlPanel" } }
+    {
+      "id": "HeaderTitlePlugin",
+      "ui": {
+        "slot": "headerLeft",
+        "module": "/plugins/header/index.ts",
+        "export": "HeaderTitle"
+      }
+    },
+    {
+      "id": "HeaderControlsPlugin",
+      "ui": {
+        "slot": "headerCenter",
+        "module": "/plugins/header/index.ts",
+        "export": "HeaderControls"
+      }
+    },
+    {
+      "id": "HeaderThemePlugin",
+      "ui": {
+        "slot": "headerRight",
+        "module": "/plugins/header/index.ts",
+        "export": "HeaderThemeToggle"
+      }
+    },
+    {
+      "id": "LibraryPlugin",
+      "ui": {
+        "slot": "library",
+        "module": "/plugins/library/index.ts",
+        "export": "LibraryPanel"
+      }
+    },
+    {
+      "id": "CanvasPlugin",
+      "ui": {
+        "slot": "canvas",
+        "module": "/plugins/canvas/index.ts",
+        "export": "CanvasPage"
+      }
+    },
+    {
+      "id": "ControlPanelPlugin",
+      "ui": {
+        "slot": "controlPanel",
+        "module": "/plugins/control-panel/index.ts",
+        "export": "ControlPanel"
+      }
+    }
   ]
 }
-

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -15,7 +15,13 @@ export async function initConductor(): Promise<ConductorClient> {
 // - Browser: fetch from /json-sequences/{plugin}/
 // - Node/test: import from json-sequences/{plugin}/ with JSON loader
 export async function loadJsonSequenceCatalogs(conductor: ConductorClient) {
-  const plugins = ["library", "library-component", "canvas-component", "control-panel"] as const;
+  const plugins = [
+    "library",
+    "library-component",
+    "canvas-component",
+    "control-panel",
+    "header",
+  ] as const;
   const isBrowser =
     typeof globalThis !== "undefined" &&
     typeof (globalThis as any).fetch === "function";

--- a/src/global.css
+++ b/src/global.css
@@ -1,7 +1,9 @@
 /* Global app-shell reset and layout helpers */
 
 /* Remove default body margin that causes white gutters on left/right */
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
 }
 
@@ -11,12 +13,61 @@ body {
 }
 
 /* Make sizing predictable throughout */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
 
 /* Avoid unexpected horizontal scrollbars */
-html, body {
+html,
+body {
   overflow-x: hidden;
 }
 
+/* Theme System - CSS Variables for Light/Dark Mode */
+:root,
+[data-theme="light"] {
+  /* Background colors */
+  --bg-color: #ffffff;
+  --bg: #fafafa;
+  --text-color: #333333;
+  --border-color: #d1d5db;
+  --hover-bg: #f3f4f6;
+
+  /* Component specific */
+  --btn-bg: linear-gradient(135deg, #4f46e5, #3b82f6);
+  --btn-color: #ffffff;
+  --btn-hover-bg: linear-gradient(135deg, #4338ca, #3730a3);
+
+  /* Panel backgrounds */
+  --panel-bg: rgba(255, 255, 255, 0.95);
+  --panel-border: rgba(0, 0, 0, 0.1);
+  --panel-shadow: rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="dark"] {
+  /* Background colors */
+  --bg-color: #1f2937;
+  --bg: #111827;
+  --text-color: #f9fafb;
+  --border-color: #374151;
+  --hover-bg: #374151;
+
+  /* Component specific */
+  --btn-bg: linear-gradient(135deg, #6366f1, #8b5cf6);
+  --btn-color: #ffffff;
+  --btn-hover-bg: linear-gradient(135deg, #5b21b6, #7c3aed);
+
+  /* Panel backgrounds */
+  --panel-bg: rgba(31, 41, 55, 0.95);
+  --panel-border: rgba(255, 255, 255, 0.1);
+  --panel-shadow: rgba(0, 0, 0, 0.3);
+}
+
+/* Apply theme to body for global background */
+body {
+  background-color: var(--bg);
+  color: var(--text-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}


### PR DESCRIPTION
feat(#72): Add headerLeft/headerCenter/headerRight slots and header plugins (title, controls, theme toggle)

Summary
- Add a header row to manifest-driven grid layout (48px)
- Register three header plugins to new header slots
- Implement HeaderThemeToggle routed via interaction-manifest and stage-crew (no UI DOM access)
- Include new header sequences in conductor loader
- Add unit test ensuring 6 slots render
- All tests and lint pass locally

Validation
- npm run pre:manifests
- npm run lint
- npm test

Notes
- Theme persistence kept out of UI code to satisfy lint rules; can be added via stage-crew/util path if desired.

Closes #72

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author