### PR TITLE
feat(#77): expand dark mode tokens and apply variable-driven theming

### DIFF
--- a/__tests__/theme/toggleTheme.spec.ts
+++ b/__tests__/theme/toggleTheme.spec.ts
@@ -1,0 +1,42 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { toggleTheme } from "../../plugins/header/symphonies/ui/ui.stage-crew";
+
+// Minimal ctx mock with payload and logger
+const makeCtx = () => ({ payload: {} as any, logger: { warn: () => {} } });
+
+describe("toggleTheme stage-crew handler", () => {
+  beforeEach(() => {
+    // Reset attribute between tests
+    if (typeof document !== "undefined") {
+      document.documentElement.removeAttribute("data-theme");
+    }
+  });
+
+  it("applies data-theme attribute on documentElement and returns theme", async () => {
+    const ctx = makeCtx();
+    const res = toggleTheme({ theme: "dark" }, ctx);
+    expect(res).toEqual({ theme: "dark" });
+    // allow rAF path to run in handler
+    await new Promise<void>((resolve) =>
+      typeof window !== "undefined" && (window as any).requestAnimationFrame
+        ? (window as any).requestAnimationFrame(() => resolve())
+        : setTimeout(() => resolve(), 0)
+    );
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(ctx.payload.theme).toBe("dark");
+  });
+
+  it("defaults to light when no theme provided", async () => {
+    const ctx = makeCtx();
+    const res = toggleTheme({}, ctx);
+    expect(res).toEqual({ theme: "light" });
+    await new Promise<void>((resolve) =>
+      typeof window !== "undefined" && (window as any).requestAnimationFrame
+        ? (window as any).requestAnimationFrame(() => resolve())
+        : setTimeout(() => resolve(), 0)
+    );
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(ctx.payload.theme).toBe("light");
+  });
+});

--- a/__tests__/ui/canvas.theme.spec.ts
+++ b/__tests__/ui/canvas.theme.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+// This test enforces that CanvasPage.css uses CSS variables for core colors
+// to support light/dark theming.
+describe("CanvasPage.css theming", () => {
+  const cssPath = path.resolve(__dirname, "../../plugins/canvas/ui/CanvasPage.css");
+  const css = fs.readFileSync(cssPath, "utf-8");
+
+  it("uses variables for background and header border", () => {
+    expect(css).toMatch(/background:\s*var\(--bg\)/);
+    expect(css).toMatch(/border-bottom:\s*1px solid var\(--panel-border\)/);
+  });
+
+  it("uses control variables and accent tokens", () => {
+    expect(css).toMatch(/background:\s*var\(--control-bg\)/);
+    expect(css).toMatch(/background:\s*var\(--control-hover-bg\)/);
+    expect(css).toMatch(/background:\s*var\(--panel-bg\)/);
+    expect(css).toMatch(/var\(--accent-bg\)/);
+    expect(css).toMatch(/var\(--accent-border\)/);
+  });
+
+  it("uses themed canvas grid dot color", () => {
+    expect(css).toMatch(/var\(--canvas-grid-dot\)/);
+  });
+});
+

--- a/__tests__/ui/panels.theme.spec.ts
+++ b/__tests__/ui/panels.theme.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+describe("Panel CSS files use theme variables", () => {
+  const files = [
+    path.resolve(__dirname, "../../plugins/library/ui/LibraryPanel.css"),
+    path.resolve(__dirname, "../../plugins/control-panel/ui/ControlPanel.css"),
+  ];
+
+  it("headers use panel header variables where present", () => {
+    const lib = fs.readFileSync(files[0], "utf-8");
+    expect(lib).toMatch(/background:\s*var\(--panel-header-bg\)/);
+  });
+
+  it("panels use panel background/border/shadow vars", () => {
+    for (const f of files) {
+      const css = fs.readFileSync(f, "utf-8");
+      expect(css).toMatch(/background:\s*var\(--panel-bg\)/);
+      expect(css).toMatch(/border-(left|right|top|bottom):\s*1px solid var\(--panel-border\)/);
+    }
+  });
+});
+

--- a/plugins/canvas/ui/CanvasPage.css
+++ b/plugins/canvas/ui/CanvasPage.css
@@ -2,7 +2,7 @@
 
 .canvas-area {
   flex: 1;
-  background: #f8fafc;
+  background: var(--bg);
   position: relative;
   overflow: hidden;
   display: flex;
@@ -10,9 +10,9 @@
 }
 
 .canvas-header {
-  background: white;
+  background: var(--panel-bg);
   padding: 12px 24px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--panel-border);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -21,7 +21,7 @@
 .canvas-title {
   font-size: 16px;
   font-weight: 600;
-  color: #111827;
+  color: var(--text-color);
 }
 
 .canvas-controls {
@@ -31,8 +31,8 @@
 }
 
 .canvas-control {
-  background: #f3f4f6;
-  border: 1px solid #d1d5db;
+  background: var(--control-bg);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 6px 12px;
   font-size: 12px;
@@ -41,20 +41,20 @@
 }
 
 .canvas-control:hover {
-  background: #e5e7eb;
-  border-color: #9ca3af;
+  background: var(--control-hover-bg);
+  border-color: var(--border-color);
 }
 
 .canvas-control.active {
-  background: #3b82f6;
-  color: white;
-  border-color: #2563eb;
+  background: var(--accent-bg);
+  color: var(--btn-color);
+  border-color: var(--accent-border);
 }
 
 .canvas-divider {
   width: 1px;
   height: 20px;
-  background: #d1d5db;
+  background: var(--divider);
   margin: 0 4px;
 }
 
@@ -62,8 +62,8 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  background: #f9fafb;
-  border: 1px solid #d1d5db;
+  background: var(--control-bg);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 4px;
 }
@@ -78,12 +78,12 @@
 }
 
 .zoom-btn:hover {
-  background: #e5e7eb;
+  background: var(--control-hover-bg);
 }
 
 .zoom-level {
   font-size: 11px;
-  color: #6b7280;
+  color: var(--muted-text);
   min-width: 35px;
   text-align: center;
 }
@@ -101,17 +101,20 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-image: 
-    radial-gradient(circle, #e5e7eb 1px, transparent 1px);
+  background-image: radial-gradient(
+    circle,
+    var(--canvas-grid-dot) 1px,
+    transparent 1px
+  );
   background-size: 20px 20px;
   opacity: 0.5;
 }
 
 .drop-indicator {
   position: absolute;
-  border: 2px dashed #3b82f6;
+  border: 2px dashed var(--accent-bg);
   border-radius: 8px;
-  background: rgba(59, 130, 246, 0.1);
+  background: var(--accent-weak-bg);
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.2s ease;

--- a/plugins/control-panel/ui/ControlPanel.css
+++ b/plugins/control-panel/ui/ControlPanel.css
@@ -13,8 +13,8 @@
 
 .control-panel-header {
   padding: 16px 20px;
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
-  color: white;
+  background: var(--panel-header-bg);
+  color: var(--panel-header-color);
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
@@ -59,7 +59,7 @@
   justify-content: center;
   height: 200px;
   text-align: center;
-  color: #6b7280;
+  color: var(--muted-text);
 }
 
 .no-selection-icon {
@@ -72,7 +72,7 @@
   font-size: 14px;
   font-weight: 500;
   margin: 0 0 8px 0;
-  color: #374151;
+  color: var(--text-color);
 }
 
 .no-selection p {
@@ -88,7 +88,7 @@
 .property-section-title {
   font-size: 11px;
   font-weight: 600;
-  color: #6b7280;
+  color: var(--muted-text);
   margin-bottom: 12px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -109,21 +109,21 @@
 .property-label {
   font-size: 12px;
   font-weight: 500;
-  color: #374151;
+  color: var(--muted-text);
 }
 
 .property-input {
   padding: 6px 8px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 12px;
-  background: #ffffff;
+  background: var(--bg-color);
 }
 
 .property-input:disabled,
 .property-input[readonly] {
-  background: #f9fafb;
-  color: #6b7280;
+  background: var(--control-bg);
+  color: var(--muted-text);
 }
 
 .class-list {
@@ -132,9 +132,9 @@
   gap: 4px;
   min-height: 24px;
   padding: 4px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: #f9fafb;
+  background: var(--control-bg);
 }
 
 .class-pill {
@@ -142,17 +142,17 @@
   align-items: center;
   gap: 4px;
   padding: 2px 6px;
-  background: #e5e7eb;
+  background: var(--control-hover-bg);
   border-radius: 12px;
   font-size: 11px;
   font-weight: 500;
-  color: #374151;
+  color: var(--text-color);
 }
 
 .class-remove-btn {
   background: none;
   border: none;
-  color: #6b7280;
+  color: var(--muted-text);
   cursor: pointer;
   font-size: 14px;
   line-height: 1;
@@ -166,7 +166,7 @@
 }
 
 .class-remove-btn:hover {
-  background: #f3f4f6;
+  background: var(--control-bg);
   color: #ef4444;
 }
 
@@ -177,8 +177,8 @@
 
 .add-class-btn {
   padding: 6px 12px;
-  background: #3b82f6;
-  color: white;
+  background: var(--accent-bg);
+  color: var(--btn-color);
   border: none;
   border-radius: 4px;
   font-size: 12px;
@@ -199,7 +199,7 @@
 }
 
 .add-class-btn:hover {
-  background: #2563eb;
+  background: var(--accent-border);
 }
 
 /* CSS Classes Management Styles */
@@ -214,22 +214,22 @@
   align-items: center;
   justify-content: space-between;
   padding: 8px 12px;
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
+  background: var(--control-bg);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   transition: all 0.2s;
 }
 
 .css-class-item:hover {
-  background: #f1f5f9;
-  border-color: #cbd5e1;
+  background: var(--control-hover-bg);
+  border-color: var(--border-color);
 }
 
 .css-class-name {
   font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
   font-size: 12px;
   font-weight: 500;
-  color: #1e293b;
+  color: var(--text-color);
   cursor: pointer;
   flex: 1;
 }
@@ -277,7 +277,7 @@
 .property-section-title {
   font-size: 12px;
   font-weight: 600;
-  color: #374151;
+  color: var(--muted-text);
   margin-bottom: 12px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -290,7 +290,7 @@
   content: "";
   flex: 1;
   height: 1px;
-  background: #e5e7eb;
+  background: var(--divider);
 }
 
 .property-grid {
@@ -316,13 +316,13 @@
 .property-label {
   font-size: 11px;
   font-weight: 500;
-  color: #6b7280;
+  color: var(--muted-text);
   margin-bottom: 4px;
 }
 
 .property-input {
   padding: 8px 10px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 12px;
   transition: all 0.2s;
@@ -330,16 +330,16 @@
 
 .property-input:focus {
   outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: var(--accent-border);
+  box-shadow: 0 0 0 3px var(--accent-weak-bg);
 }
 
 .property-select {
   padding: 8px 10px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 12px;
-  background: white;
+  background: var(--bg-color);
 }
 
 .property-checkbox {
@@ -368,7 +368,7 @@
 .color-swatch {
   width: 24px;
   height: 24px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   cursor: pointer;
 }
@@ -378,7 +378,7 @@
   gap: 8px;
   margin-top: 16px;
   padding-top: 16px;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--divider);
 }
 
 /* New field renderer styles */
@@ -490,26 +490,26 @@
 .action-btn {
   flex: 1;
   padding: 8px 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--border-color);
   border-radius: 6px;
-  background: white;
+  background: var(--bg-color);
   font-size: 11px;
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .action-btn:hover {
-  background: #f3f4f6;
+  background: var(--control-hover-bg);
 }
 
 .action-btn.primary {
-  background: #3b82f6;
-  color: white;
-  border-color: #2563eb;
+  background: var(--accent-bg);
+  color: var(--btn-color);
+  border-color: var(--accent-border);
 }
 
 .action-btn.primary:hover {
-  background: #2563eb;
+  background: var(--accent-border);
 }
 
 .action-btn.danger {

--- a/plugins/library/ui/LibraryPanel.css
+++ b/plugins/library/ui/LibraryPanel.css
@@ -13,8 +13,8 @@
 
 .library-sidebar-header {
   padding: 20px;
-  background: linear-gradient(135deg, #4f46e5, #3b82f6);
-  color: white;
+  background: var(--panel-header-bg);
+  color: var(--panel-header-color);
   text-align: center;
 }
 
@@ -44,7 +44,7 @@
 .library-category-title {
   font-size: 14px;
   font-weight: 600;
-  color: #374151;
+  color: var(--muted-text);
   margin-bottom: 12px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -58,8 +58,8 @@
 
 .library-component-item {
   cursor: grab;
-  background: white;
-  border: 2px solid #e5e7eb;
+  background: var(--panel-bg);
+  border: 2px solid var(--border-color);
   border-radius: 12px;
   padding: 16px;
   transition: all 0.3s ease;
@@ -69,9 +69,9 @@
 }
 
 .library-component-item:hover {
-  border-color: #3b82f6;
+  border-color: var(--accent-border);
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.15);
+  box-shadow: 0 4px 12px var(--panel-shadow);
 }
 
 .library-component-icon {
@@ -83,12 +83,12 @@
 .library-component-name {
   font-size: 12px;
   font-weight: 500;
-  color: #111827;
+  color: var(--text-color);
   margin-bottom: 4px;
 }
 
 .library-component-description {
   font-size: 10px;
-  color: #6b7280;
+  color: var(--muted-text);
   line-height: 1.3;
 }

--- a/src/global.css
+++ b/src/global.css
@@ -35,6 +35,18 @@ body {
   --border-color: #d1d5db;
   --hover-bg: #f3f4f6;
 
+  /* Control and UI surfaces */
+  --control-bg: #f3f4f6;
+  --control-hover-bg: #e5e7eb;
+  --muted-text: #6b7280;
+  --divider: #d1d5db;
+  --canvas-grid-dot: #e5e7eb;
+
+  /* Accent colors */
+  --accent-bg: #3b82f6;
+  --accent-border: #2563eb;
+  --accent-weak-bg: rgba(59, 130, 246, 0.1);
+
   /* Component specific */
   --btn-bg: linear-gradient(135deg, #4f46e5, #3b82f6);
   --btn-color: #ffffff;
@@ -44,15 +56,29 @@ body {
   --panel-bg: rgba(255, 255, 255, 0.95);
   --panel-border: rgba(0, 0, 0, 0.1);
   --panel-shadow: rgba(0, 0, 0, 0.05);
+  --panel-header-bg: linear-gradient(135deg, #4f46e5, #3b82f6);
+  --panel-header-color: #ffffff;
 }
 
 [data-theme="dark"] {
   /* Background colors */
   --bg-color: #1f2937;
-  --bg: #111827;
-  --text-color: #f9fafb;
-  --border-color: #374151;
-  --hover-bg: #374151;
+  --bg: #0a0a0b;
+  --text-color: #f8fafc;
+  --border-color: #333344;
+  --hover-bg: #1f2937;
+
+  /* Control and UI surfaces */
+  --control-bg: rgba(255, 255, 255, 0.05);
+  --control-hover-bg: rgba(255, 255, 255, 0.1);
+  --muted-text: #a9b1c4;
+  --divider: rgba(255, 255, 255, 0.15);
+  --canvas-grid-dot: rgba(255, 255, 255, 0.08);
+
+  /* Accent colors */
+  --accent-bg: #3b82f6;
+  --accent-border: #2563eb;
+  --accent-weak-bg: rgba(59, 130, 246, 0.12);
 
   /* Component specific */
   --btn-bg: linear-gradient(135deg, #6366f1, #8b5cf6);
@@ -60,9 +86,10 @@ body {
   --btn-hover-bg: linear-gradient(135deg, #5b21b6, #7c3aed);
 
   /* Panel backgrounds */
-  --panel-bg: rgba(31, 41, 55, 0.95);
+  --panel-bg: rgba(31, 41, 55, 0.7);
   --panel-border: rgba(255, 255, 255, 0.1);
   --panel-shadow: rgba(0, 0, 0, 0.3);
+  --panel-header-bg: linear-gradient(135deg, #1e1e2e, #2a2a3a);
 }
 
 /* Apply theme to body for global background */


### PR DESCRIPTION
This PR enhances dark mode coverage to align with the prototype.

Changes
- Extend theme tokens in src/global.css for light/dark (control surfaces, accents, panel header)
- Replace hard-coded colors with CSS variables in:
  - plugins/canvas/ui/CanvasPage.css
  - plugins/library/ui/LibraryPanel.css
  - plugins/control-panel/ui/ControlPanel.css
- Add tests:
  - __tests__/theme/toggleTheme.spec.ts (verifies data-theme handling)
  - __tests__/ui/canvas.theme.spec.ts (enforces variable usage)
  - __tests__/ui/panels.theme.spec.ts (enforces variable usage)

Notes
- No dependency changes. No architectural changes.
- Kept edits minimal and variable-driven per repo guidelines.

Closes #77.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author