### PR TITLE
feat(svg): generic SVG component with innerHtml rule and tests

### DIFF
--- a/__tests__/canvas-component/svg.basic.spec.ts
+++ b/__tests__/canvas-component/svg.basic.spec.ts
@@ -1,0 +1,54 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+
+function makeSvgTemplate() {
+  return {
+  tag: "svg",
+  classes: ["rx-comp", "rx-svg"],
+    css: ".rx-svg * { vector-effect: non-scaling-stroke; }",
+    dimensions: { width: 900, height: 500 },
+    // content delivered via content rules (viewBox, preserveAspectRatio)
+    content: {
+      viewBox: "0 0 900 500",
+      preserveAspectRatio: "xMidYMid meet",
+      svgMarkup: "<defs><marker id='arrow' /></defs><g class='layer'></g>"
+    },
+  metadata: { type: "svg" }
+  } as any;
+}
+
+function makeCtx() {
+  return { payload: {} } as any;
+}
+
+describe("SVG component (generic)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="rx-canvas" style="position:relative"></div>';
+  });
+
+  it("creates an <svg.rx-svg> with viewBox/preserveAspectRatio and applies innerHtml", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector('#rx-canvas svg.rx-svg') as SVGSVGElement | null;
+    expect(svg).toBeTruthy();
+
+    // Attributes from content rules
+    expect(svg!.getAttribute('viewBox')).toBe('0 0 900 500');
+    expect(svg!.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet');
+
+    // Inner markup applied
+    const defs = svg!.querySelector('defs');
+    expect(defs).toBeTruthy();
+    const marker = defs!.querySelector('marker#arrow');
+    expect(marker).toBeTruthy();
+
+    // Non-scaling stroke rule present in injected CSS (jsdom can't compute)
+    const styleEl = document.getElementById('rx-components-styles') as HTMLStyleElement | null;
+    expect(styleEl?.textContent || '').toContain('non-scaling-stroke');
+  });
+});

--- a/__tests__/canvas-component/svg.resize.spec.ts
+++ b/__tests__/canvas-component/svg.resize.spec.ts
@@ -1,0 +1,67 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+import { handlers as resizeMoveHandlers } from "../../plugins/canvas-component/symphonies/resize/resize.move.symphony";
+
+function makeSvgTemplate() {
+  return {
+    tag: "svg",
+    classes: ["rx-comp", "rx-svg"],
+    css: ".rx-svg * { vector-effect: non-scaling-stroke; }",
+    dimensions: { width: 300, height: 200 },
+    content: {
+      viewBox: "0 0 300 200",
+      preserveAspectRatio: "xMidYMid meet",
+      svgMarkup: "<rect id='r1' x='0' y='0' width='300' height='200' stroke='black' fill='none' />"
+    },
+  metadata: { type: "svg" }
+  } as any;
+}
+
+function makeCtx() { return { payload: {} } as any; }
+
+describe("SVG component resize", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="rx-canvas" style="position:relative"></div>';
+  });
+
+  it("resizes outer dimensions without removing inner content and preserves non-scaling stroke styling", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 5, y: 10 } } as any, ctx);
+
+    const id = ctx.payload.nodeId as string;
+    const el = document.getElementById(id)! as HTMLElement;
+
+    expect(el.style.width).toBe('300px');
+    expect(el.style.height).toBe('200px');
+
+    // Perform resize
+    const payload = {
+      id,
+      dir: 'se',
+      startLeft: 5,
+      startTop: 10,
+      startWidth: 300,
+      startHeight: 200,
+      dx: 120,
+      dy: 80,
+      phase: 'move'
+    } as any;
+
+    resizeMoveHandlers.updateSize?.(payload, {} as any);
+
+    expect(el.style.width).toBe('420px');
+    expect(el.style.height).toBe('280px');
+
+    // Inner content remains
+    const rect = el.querySelector('rect#r1');
+    expect(rect).toBeTruthy();
+
+    // CSS rule still present
+    const styleEl = document.getElementById('rx-components-styles') as HTMLStyleElement | null;
+    expect(styleEl?.textContent || '').toContain('non-scaling-stroke');
+  });
+});

--- a/plugins/canvas-component/symphonies/create/create.stage-crew.ts
+++ b/plugins/canvas-component/symphonies/create/create.stage-crew.ts
@@ -92,8 +92,8 @@ export const createNode = (data: any, ctx: any) => {
     } catch {}
   }
 
-  // 6.6) If this is an SVG line, append a child <line> and set svg attributes
-  if (String(tpl?.tag).toLowerCase() === "svg") {
+  // 6.6) If this is the legacy SVG line component, append a child <line> and set svg attributes
+  if (String(tpl?.tag).toLowerCase() === "svg" && tpl?.metadata?.type === "line") {
     try {
       const svg = el as unknown as SVGSVGElement;
       svg.setAttribute("width", "100%");

--- a/public/json-components/component.mapper.json
+++ b/public/json-components/component.mapper.json
@@ -5,7 +5,8 @@
       { "when": "metadata.type == 'container'", "tag": "div" },
       { "when": "metadata.type == 'input'", "tag": "input" },
       { "when": "metadata.type == 'image'", "tag": "img" },
-      { "when": "metadata.type == 'line'", "tag": "svg" },
+  { "when": "metadata.type == 'line'", "tag": "svg" },
+  { "when": "metadata.type == 'svg'", "tag": "svg" },
       { "when": "metadata.type == 'paragraph'", "tag": "p" },
       {
         "when": "metadata.type == 'heading'",
@@ -17,6 +18,15 @@
       },
       { "defaultTag": "div" }
     ]
+  },
+  "contentRules": {
+    "byType": {
+      "svg": [
+        { "action": "attr", "attr": "viewBox", "from": "viewBox" },
+        { "action": "attr", "attr": "preserveAspectRatio", "from": "preserveAspectRatio" },
+        { "action": "innerHtml", "from": "svgMarkup" }
+      ]
+    }
   }
 }
 

--- a/public/json-components/index.json
+++ b/public/json-components/index.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "description": "Index of available JSON components for RenderX Evolution",
   "lastUpdated": "2025-08-26",
-  "components": ["button.json", "input.json", "line.json", "container.json", "heading.json", "image.json", "paragraph.json"],
+  "components": ["button.json", "input.json", "line.json", "container.json", "heading.json", "image.json", "paragraph.json", "svg.json"],
   "metadata": {
     "totalComponents": 7,
     "categories": ["basic"],

--- a/public/json-components/svg.json
+++ b/public/json-components/svg.json
@@ -1,0 +1,35 @@
+{
+  "metadata": {
+    "type": "svg",
+    "name": "SVG",
+    "version": "1.0.0",
+    "category": "basic"
+  },
+  "ui": {
+    "template": "<svg class=\"rx-comp rx-svg\"></svg>",
+    "styles": {
+      "css": ".rx-svg * { vector-effect: non-scaling-stroke; }",
+      "variables": { "bg": "transparent" }
+    },
+    "icon": { "mode": "emoji", "value": "🖼️" }
+  },
+  "integration": {
+    "properties": {
+      "schema": {
+        "viewBox": { "type": "string", "default": "0 0 900 500" },
+        "preserveAspectRatio": { "type": "string", "default": "xMidYMid meet" },
+        "svgMarkup": { "type": "string", "default": "" }
+      },
+      "defaultValues": { "viewBox": "0 0 900 500", "preserveAspectRatio": "xMidYMid meet" }
+    },
+    "canvasIntegration": { "resizable": true, "draggable": true, "selectable": true, "defaultWidth": 900, "defaultHeight": 500 }
+  },
+  "interactions": {
+    "canvas.component.create": { "pluginId": "CanvasComponentPlugin", "sequenceId": "canvas-component-create-symphony" },
+    "canvas.component.select": { "pluginId": "CanvasComponentSelectionPlugin", "sequenceId": "canvas-component-select-symphony" },
+    "canvas.component.drag.move": { "pluginId": "CanvasComponentDragPlugin", "sequenceId": "canvas-component-drag-symphony" },
+    "canvas.component.resize.start": { "pluginId": "CanvasComponentResizeStartPlugin", "sequenceId": "canvas-component-resize-start-symphony" },
+    "canvas.component.resize.move": { "pluginId": "CanvasComponentResizeMovePlugin", "sequenceId": "canvas-component-resize-move-symphony" },
+    "canvas.component.resize.end": { "pluginId": "CanvasComponentResizeEndPlugin", "sequenceId": "canvas-component-resize-end-symphony" }
+  }
+}


### PR DESCRIPTION
Adds a new generic SVG component and rule-engine support for innerHtml content rule.\n\nChanges:\n- Added svg.json component definition with viewBox, preserveAspectRatio, svgMarkup schema.\n- Updated index.json and component.mapper.json for svg tag + content rules.\n- Extended rule-engine with innerHtml action and default svg content rules.\n- Adjusted create.stage-crew.ts to limit legacy line child creation to type==='line'.\n- Added tests: svg.basic.spec.ts & svg.resize.spec.ts.\n\nTests pass. Follow-ups: ADR for innerHtml, validation handling, export/import tests, shapes[] model.