### PR TITLE
feat(#85): SVG Markup editor (Import/Format/Full‑screen), paste extraction, preserveAspectRatio presets, debounced updates

### DIFF
--- a/__tests__/control-panel/svg.code-editor.mapping.spec.ts
+++ b/__tests__/control-panel/svg.code-editor.mapping.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { SchemaResolverService } from "../../plugins/control-panel/services/schema-resolver.service";
+import type { ControlPanelConfig, SelectedElement, ComponentSchema } from "../../plugins/control-panel/types/control-panel.types";
+
+function loadJson<T = any>(p: string): T {
+  const txt = fs.readFileSync(p, "utf-8");
+  return JSON.parse(txt) as T;
+}
+
+describe("SVG schema → code editor mapping", () => {
+  it("maps ui.control = code to field.type = 'code' and applies preserveAspectRatio enum presets", async () => {
+    const root = path.resolve(__dirname, "../../");
+    const config = loadJson<ControlPanelConfig>(path.join(root, "plugins/control-panel/config/control-panel.schema.json"));
+    const svgSchema = loadJson<ComponentSchema>(path.join(root, "json-components/svg.json"));
+
+    const resolver = new SchemaResolverService(config);
+    resolver.registerComponentSchema("svg", svgSchema);
+
+    const selected: SelectedElement = {
+      header: { type: "svg", id: "node-1", componentSchema: svgSchema },
+      content: {},
+      layout: { x: 0, y: 0, width: 100, height: 100 },
+      styling: {},
+      classes: [],
+      events: {},
+    };
+
+    const fields = resolver.generatePropertyFields(selected);
+
+    const markupField = fields.find((f) => f.key === "svgMarkup");
+    expect(markupField).toBeTruthy();
+    expect(markupField!.type).toBe("code");
+
+    const parField = fields.find((f) => f.key === "preserveAspectRatio");
+    expect(parField?.options?.length).toBeGreaterThan(0);
+    const labels = (parField?.options || []).map((o) => String(o.value));
+    expect(labels).toContain("xMidYMid meet");
+    expect(labels).toContain("xMidYMid slice");
+  });
+});
+

--- a/json-components/json-topics/control-panel.json
+++ b/json-components/json-topics/control-panel.json
@@ -75,6 +75,7 @@
       "perfGuards": {
         "throttle": { "intervalMs": 100 }
       },
+      "perf": { "debounceMs": 250 },
       "notes": "Control panel field change requested; routes to field change sequence with throttling."
     },
     "control.panel.ui.field.validate.requested": {

--- a/json-components/svg.json
+++ b/json-components/svg.json
@@ -23,11 +23,52 @@
   "integration": {
     "properties": {
       "schema": {
-        "viewBox": { "type": "string", "default": "0 0 900 500", "description": "SVG viewBox attribute" },
-        "preserveAspectRatio": { "type": "string", "default": "xMidYMid meet", "description": "SVG preserveAspectRatio attribute" },
-        "svgMarkup": { "type": "string", "default": "", "description": "Inner SVG markup to render (pasted contents)" }
+        "viewBox": {
+          "type": "string",
+          "default": "0 0 900 500",
+          "description": "SVG viewBox attribute"
+        },
+        "preserveAspectRatio": {
+          "type": "string",
+          "default": "xMidYMid meet",
+          "description": "SVG preserveAspectRatio attribute",
+          "enum": [
+            "none",
+            "xMinYMin meet",
+            "xMidYMin meet",
+            "xMaxYMin meet",
+            "xMinYMid meet",
+            "xMidYMid meet",
+            "xMaxYMid meet",
+            "xMinYMax meet",
+            "xMidYMax meet",
+            "xMaxYMax meet",
+            "xMinYMin slice",
+            "xMidYMin slice",
+            "xMaxYMin slice",
+            "xMinYMid slice",
+            "xMidYMid slice",
+            "xMaxYMid slice",
+            "xMinYMax slice",
+            "xMidYMax slice",
+            "xMaxYMax slice"
+          ]
+        },
+        "svgMarkup": {
+          "type": "string",
+          "default": "",
+          "description": "Inner SVG markup to render (pasted contents)",
+          "ui": {
+            "control": "code",
+            "rows": 8,
+            "placeholder": "Paste inner SVG markup or full <svg>…"
+          }
+        }
       },
-      "defaultValues": { "viewBox": "0 0 900 500", "preserveAspectRatio": "xMidYMid meet" }
+      "defaultValues": {
+        "viewBox": "0 0 900 500",
+        "preserveAspectRatio": "xMidYMid meet"
+      }
     },
     "canvasIntegration": {
       "resizable": true,
@@ -38,12 +79,29 @@
     }
   },
   "interactions": {
-    "canvas.component.create": { "pluginId": "CanvasComponentPlugin", "sequenceId": "canvas-component-create-symphony" },
-    "canvas.component.select": { "pluginId": "CanvasComponentSelectionPlugin", "sequenceId": "canvas-component-select-symphony" },
-    "canvas.component.drag.move": { "pluginId": "CanvasComponentDragPlugin", "sequenceId": "canvas-component-drag-symphony" },
-    "canvas.component.resize.start": { "pluginId": "CanvasComponentResizeStartPlugin", "sequenceId": "canvas-component-resize-start-symphony" },
-    "canvas.component.resize.move": { "pluginId": "CanvasComponentResizeMovePlugin", "sequenceId": "canvas-component-resize-move-symphony" },
-    "canvas.component.resize.end": { "pluginId": "CanvasComponentResizeEndPlugin", "sequenceId": "canvas-component-resize-end-symphony" }
+    "canvas.component.create": {
+      "pluginId": "CanvasComponentPlugin",
+      "sequenceId": "canvas-component-create-symphony"
+    },
+    "canvas.component.select": {
+      "pluginId": "CanvasComponentSelectionPlugin",
+      "sequenceId": "canvas-component-select-symphony"
+    },
+    "canvas.component.drag.move": {
+      "pluginId": "CanvasComponentDragPlugin",
+      "sequenceId": "canvas-component-drag-symphony"
+    },
+    "canvas.component.resize.start": {
+      "pluginId": "CanvasComponentResizeStartPlugin",
+      "sequenceId": "canvas-component-resize-start-symphony"
+    },
+    "canvas.component.resize.move": {
+      "pluginId": "CanvasComponentResizeMovePlugin",
+      "sequenceId": "canvas-component-resize-move-symphony"
+    },
+    "canvas.component.resize.end": {
+      "pluginId": "CanvasComponentResizeEndPlugin",
+      "sequenceId": "canvas-component-resize-end-symphony"
+    }
   }
 }
-

--- a/plugins/control-panel/components/field-renderers/CodeTextarea.tsx
+++ b/plugins/control-panel/components/field-renderers/CodeTextarea.tsx
@@ -1,0 +1,241 @@
+import React from "react";
+import type { FieldRendererProps } from "../../types/control-panel.types";
+import { useControlPanelSequences } from "../../hooks/useControlPanelSequences";
+import { CodeEditorModal } from "../modals/CodeEditorModal";
+
+export const CodeTextarea: React.FC<FieldRendererProps> = ({
+  field,
+  value,
+  onChange,
+  onValidate,
+  disabled = false,
+  className = "",
+  selectedElement = null,
+}) => {
+  const sequences = useControlPanelSequences();
+  const [localValue, setLocalValue] = React.useState<string>(value || "");
+  const [errors, setErrors] = React.useState<string[]>([]);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [showExtract, setShowExtract] = React.useState(false);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const rows = field.rendererProps?.rows ?? 8;
+  const placeholder = field.rendererProps?.placeholder ?? "Paste SVG markup…";
+
+  React.useEffect(() => {
+    setLocalValue(value || "");
+  }, [value]);
+
+  function validateAndReport(next: string) {
+    const errs: string[] = [];
+    if (field.required && !next.trim()) errs.push(`${field.label} is required`);
+    setErrors(errs);
+    onValidate?.(errs.length === 0, errs);
+  }
+
+  function detectExtractCandidate(text: string) {
+    const hasSvgRoot = /^\s*<svg[\s>]/i.test(text || "");
+    setShowExtract(hasSvgRoot);
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const next = e.target.value;
+    setLocalValue(next);
+    validateAndReport(next);
+    detectExtractCandidate(next);
+    onChange(next);
+  };
+
+  function prettyPrintXml(xml: string): string {
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(
+        `<root>${xml}</root>`,
+        "application/xml"
+      );
+      const err = doc.querySelector("parsererror");
+      if (err) throw new Error(err.textContent || "XML parse error");
+      const serializer = new XMLSerializer();
+      const raw = serializer.serializeToString(doc.documentElement);
+      // Remove outer wrapper and add simple indentation
+      const inner = raw.replace(/^<root>|<\/root>$/g, "");
+      const tokens = inner
+        .replace(/>\s+</g, "><")
+        .replace(/></g, ">\n<")
+        .split("\n");
+      let indent = 0;
+      return tokens
+        .map((t) => {
+          if (/^<\//.test(t)) indent = Math.max(0, indent - 1);
+          const line = `${"  ".repeat(indent)}${t}`;
+          if (/^<[^!?][^>]*[^/]>$/.test(t)) indent += 1; // opening tag
+          return line;
+        })
+        .join("\n");
+    } catch (e: any) {
+      setErrors([e?.message || "Failed to format XML"]);
+      onValidate?.(false, [e?.message || "Failed to format XML"]);
+      return xml;
+    }
+  }
+
+  function handleFormat() {
+    const formatted = prettyPrintXml(localValue);
+    setLocalValue(formatted);
+    onChange(formatted);
+  }
+
+  function handleImportClick() {
+    fileInputRef.current?.click();
+  }
+
+  async function handleImportFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    const text = await f.text();
+    setLocalValue(text);
+    detectExtractCandidate(text);
+    onChange(text);
+  }
+
+  function extractFromFullSvg(text: string) {
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(text, "image/svg+xml");
+      const svg = doc.querySelector("svg");
+      if (!svg) throw new Error("No <svg> root found");
+      const viewBox = svg.getAttribute("viewBox") || undefined;
+      const par = svg.getAttribute("preserveAspectRatio") || undefined;
+      // Prefer innerHTML from the parsed SVG document to avoid touching global DOM
+      const inner =
+        (svg as unknown as { innerHTML?: string }).innerHTML ??
+        new XMLSerializer()
+          .serializeToString(svg)
+          .replace(/^<svg[^>]*>/i, "")
+          .replace(/<\/svg>$/i, "");
+
+      // Dispatch updates via sequences for multi-field changes
+      if (sequences.isInitialized && selectedElement) {
+        sequences.handleFieldChange("svgMarkup", inner, selectedElement);
+        if (viewBox)
+          sequences.handleFieldChange("viewBox", viewBox, selectedElement);
+        if (par)
+          sequences.handleFieldChange(
+            "preserveAspectRatio",
+            par,
+            selectedElement
+          );
+      } else {
+        // Fallback to onChange for content
+        onChange(inner);
+      }
+
+      setLocalValue(inner);
+      setShowExtract(false);
+      validateAndReport(inner);
+    } catch (e: any) {
+      setErrors([e?.message || "Failed to extract from <svg>"]);
+      onValidate?.(false, [e?.message || "Failed to extract from <svg>"]);
+    }
+  }
+
+  return (
+    <div className={`field-input code-textarea ${className}`}>
+      <div className="code-toolbar">
+        <button
+          className="action-btn"
+          type="button"
+          onClick={handleImportClick}
+          disabled={disabled}
+          title="Import SVG file"
+        >
+          Import
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".svg,image/svg+xml"
+          style={{ display: "none" }}
+          onChange={handleImportFile}
+        />
+        <button
+          className="action-btn"
+          type="button"
+          onClick={handleFormat}
+          disabled={disabled}
+          title="Format XML"
+        >
+          Format
+        </button>
+        <button
+          className="action-btn"
+          type="button"
+          onClick={() => setIsModalOpen(true)}
+          disabled={disabled}
+          title="Full-screen editor"
+        >
+          Full‑screen
+        </button>
+      </div>
+
+      {showExtract && (
+        <div
+          className="extract-prompt"
+          style={{ marginBottom: 6, fontSize: 12 }}
+        >
+          Detected full <code>&lt;svg&gt;</code> markup. Extract inner markup
+          and apply attributes?
+          <div style={{ display: "inline-flex", gap: 8, marginLeft: 8 }}>
+            <button
+              type="button"
+              onClick={() => extractFromFullSvg(localValue)}
+            >
+              Apply
+            </button>
+            <button type="button" onClick={() => setShowExtract(false)}>
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      <textarea
+        className="property-input"
+        rows={rows}
+        placeholder={placeholder}
+        value={localValue}
+        onChange={handleChange}
+        disabled={disabled}
+        spellCheck={false}
+        style={{
+          fontFamily:
+            "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+        }}
+        title={field.description}
+      />
+
+      {errors.length > 0 && (
+        <div className="field-errors">
+          {errors.map((err, i) => (
+            <div key={i} className="field-error">
+              {err}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <CodeEditorModal
+        isOpen={isModalOpen}
+        className="code-editor-modal"
+        content={localValue}
+        onSave={(content) => {
+          setIsModalOpen(false);
+          setLocalValue(content);
+          validateAndReport(content);
+          onChange(content);
+        }}
+        onCancel={() => setIsModalOpen(false)}
+      />
+    </div>
+  );
+};

--- a/plugins/control-panel/components/field-renderers/index.ts
+++ b/plugins/control-panel/components/field-renderers/index.ts
@@ -1,17 +1,19 @@
 // Field Renderer Components - Extensible field type system
-export { TextInput } from './TextInput';
-export { NumberInput } from './NumberInput';
-export { SelectInput } from './SelectInput';
-export { CheckboxInput } from './CheckboxInput';
-export { ColorInput } from './ColorInput';
+export { TextInput } from "./TextInput";
+export { NumberInput } from "./NumberInput";
+export { SelectInput } from "./SelectInput";
+export { CheckboxInput } from "./CheckboxInput";
+export { ColorInput } from "./ColorInput";
+export { CodeTextarea } from "./CodeTextarea";
 
 // Field Renderer Registry
-import type { FieldRendererProps } from '../../types/control-panel.types';
-import { TextInput } from './TextInput';
-import { NumberInput } from './NumberInput';
-import { SelectInput } from './SelectInput';
-import { CheckboxInput } from './CheckboxInput';
-import { ColorInput } from './ColorInput';
+import type { FieldRendererProps } from "../../types/control-panel.types";
+import { TextInput } from "./TextInput";
+import { NumberInput } from "./NumberInput";
+import { SelectInput } from "./SelectInput";
+import { CheckboxInput } from "./CheckboxInput";
+import { ColorInput } from "./ColorInput";
+import { CodeTextarea } from "./CodeTextarea";
 
 export type FieldRenderer = React.ComponentType<FieldRendererProps>;
 
@@ -20,7 +22,8 @@ export const FIELD_RENDERERS: Record<string, FieldRenderer> = {
   NumberInput,
   SelectInput,
   CheckboxInput,
-  ColorInput
+  ColorInput,
+  CodeTextarea,
 };
 
 /**
@@ -36,13 +39,14 @@ export function registerFieldRenderer(type: string, component: FieldRenderer) {
 export function getFieldRenderer(type: string): FieldRenderer {
   // Map field types to component names
   const typeToComponent: Record<string, string> = {
-    'text': 'TextInput',
-    'number': 'NumberInput',
-    'select': 'SelectInput',
-    'checkbox': 'CheckboxInput',
-    'color': 'ColorInput'
+    text: "TextInput",
+    number: "NumberInput",
+    select: "SelectInput",
+    checkbox: "CheckboxInput",
+    color: "ColorInput",
+    code: "CodeTextarea",
   };
 
-  const componentName = typeToComponent[type] || 'TextInput';
+  const componentName = typeToComponent[type] || "TextInput";
   return FIELD_RENDERERS[componentName] || TextInput;
 }

--- a/plugins/control-panel/components/modals/CodeEditorModal.tsx
+++ b/plugins/control-panel/components/modals/CodeEditorModal.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import "./CssEditorModal.css"; // reuse styles
+
+export interface CodeEditorModalProps {
+  isOpen: boolean;
+  className?: string;
+  content: string;
+  onSave: (content: string) => void;
+  onCancel: () => void;
+}
+
+export const CodeEditorModal: React.FC<CodeEditorModalProps> = ({
+  isOpen,
+  className = "",
+  content,
+  onSave,
+  onCancel,
+}) => {
+  const [local, setLocal] = React.useState(content);
+  const [hasChanges, setHasChanges] = React.useState(false);
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  React.useEffect(() => {
+    setLocal(content);
+    setHasChanges(false);
+  }, [content, isOpen]);
+
+  React.useEffect(() => {
+    if (isOpen && textareaRef.current) {
+      setTimeout(() => textareaRef.current?.focus(), 100);
+    }
+  }, [isOpen]);
+
+  const modalContent = (
+    <div className={`modal-overlay ${isOpen ? "open" : ""}`}>
+      <div className={`modal ${className}`}>
+        <div className="modal-header">
+          <h3>Full-screen Editor</h3>
+          <div className="modal-actions">
+            <button onClick={() => onCancel()}>Close</button>
+            <button
+              className="primary"
+              disabled={!hasChanges}
+              onClick={() => onSave(local)}
+              title={hasChanges ? "Apply changes" : "No changes to apply"}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+        <div className="modal-content">
+          <textarea
+            ref={textareaRef}
+            className="css-editor-textarea"
+            value={local}
+            onChange={(e) => {
+              setLocal(e.target.value);
+              setHasChanges(true);
+            }}
+            spellCheck={false}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  return isOpen
+    ? createPortal(modalContent, (globalThis as any).document?.body || null)
+    : null;
+};

--- a/plugins/control-panel/components/sections/PropertyFieldRenderer.tsx
+++ b/plugins/control-panel/components/sections/PropertyFieldRenderer.tsx
@@ -1,8 +1,11 @@
-import React from 'react';
-import { getFieldRenderer } from '../field-renderers';
-import { getNestedValue } from '../../utils/field.utils';
-import { useControlPanelSequences } from '../../hooks/useControlPanelSequences';
-import type { PropertyField, SelectedElement } from '../../types/control-panel.types';
+import React from "react";
+import { getFieldRenderer } from "../field-renderers";
+import { getNestedValue } from "../../utils/field.utils";
+import { useControlPanelSequences } from "../../hooks/useControlPanelSequences";
+import type {
+  PropertyField,
+  SelectedElement,
+} from "../../types/control-panel.types";
 
 interface PropertyFieldProps {
   field: PropertyField;
@@ -15,10 +18,11 @@ export const PropertyFieldRenderer: React.FC<PropertyFieldProps> = ({
   field,
   selectedElement,
   onChange,
-  onValidate
+  onValidate,
 }) => {
   const FieldComponent = getFieldRenderer(field.type);
-  const value = getNestedValue(selectedElement, field.path) || field.defaultValue;
+  const value =
+    getNestedValue(selectedElement, field.path) || field.defaultValue;
   const sequences = useControlPanelSequences();
 
   const handleValidate = (isValid: boolean, errors: string[]) => {
@@ -43,6 +47,7 @@ export const PropertyFieldRenderer: React.FC<PropertyFieldProps> = ({
         value={value}
         onChange={(newValue) => onChange(field.key, newValue)}
         onValidate={handleValidate}
+        selectedElement={selectedElement}
       />
       {field.description && field.type !== "checkbox" && (
         <div className="field-description">{field.description}</div>

--- a/plugins/control-panel/services/schema-resolver.service.ts
+++ b/plugins/control-panel/services/schema-resolver.service.ts
@@ -104,14 +104,16 @@ export class SchemaResolverService {
       const properties = schema.integration.properties.schema;
 
       Object.entries(properties).forEach(([key, propSchema]) => {
+        const ui: any = (propSchema as any).ui || {};
+        const initialType = this.mapSchemaTypeToFieldType(
+          propSchema.type,
+          propSchema.enum,
+          key
+        );
         const field: PropertyField = {
           key,
           label: this.formatLabel(key),
-          type: this.mapSchemaTypeToFieldType(
-            propSchema.type,
-            propSchema.enum,
-            key
-          ),
+          type: ui.control === "code" ? "code" : initialType,
           path: this.inferPropertyPath(key, selectedElement),
           section: this.inferSection(key),
           required: propSchema.required || false,
@@ -124,6 +126,7 @@ export class SchemaResolverService {
                 label: this.formatLabel(value.toString()),
               }))
             : undefined,
+          rendererProps: ui && Object.keys(ui).length ? { ...ui } : undefined,
         };
 
         if (propSchema.validation) {

--- a/plugins/control-panel/types/control-panel.types.ts
+++ b/plugins/control-panel/types/control-panel.types.ts
@@ -14,7 +14,7 @@ export interface SectionConfig {
   order: number;
   collapsible: boolean;
   defaultExpanded: boolean;
-  special?: 'classes' | 'events' | 'custom';
+  special?: "classes" | "events" | "custom";
 }
 
 export interface FieldTypeConfig {
@@ -47,6 +47,7 @@ export interface PropertyField {
   description?: string;
   defaultValue?: any;
   conditional?: ConditionalRule;
+  rendererProps?: Record<string, any>;
 }
 
 export interface FieldOption {
@@ -57,14 +58,14 @@ export interface FieldOption {
 }
 
 export interface ValidationRule {
-  type: 'required' | 'min' | 'max' | 'pattern' | 'custom';
+  type: "required" | "min" | "max" | "pattern" | "custom";
   value?: any;
   message?: string;
 }
 
 export interface ConditionalRule {
   field: string;
-  operator: 'equals' | 'not-equals' | 'contains' | 'greater-than' | 'less-than';
+  operator: "equals" | "not-equals" | "contains" | "greater-than" | "less-than";
   value: any;
 }
 
@@ -91,6 +92,7 @@ export interface PropertySchema {
   required?: boolean;
   enum?: string[];
   validation?: ValidationRule[];
+  ui?: { control?: string; [key: string]: any };
 }
 
 // Selection Model
@@ -120,6 +122,7 @@ export interface FieldRendererProps {
   onValidate?: (isValid: boolean, errors: string[]) => void;
   disabled?: boolean;
   className?: string;
+  selectedElement?: SelectedElement | null;
 }
 
 // Control Panel State
@@ -132,10 +135,10 @@ export interface ControlPanelState {
 }
 
 // Action Types
-export type ControlPanelAction = 
-  | { type: 'SET_SELECTED_ELEMENT'; payload: SelectedElement | null }
-  | { type: 'SET_CLASSES'; payload: string[] }
-  | { type: 'TOGGLE_SECTION'; payload: string }
-  | { type: 'SET_VALIDATION_ERRORS'; payload: Record<string, string[]> }
-  | { type: 'SET_DIRTY'; payload: boolean }
-  | { type: 'RESET_STATE' };
+export type ControlPanelAction =
+  | { type: "SET_SELECTED_ELEMENT"; payload: SelectedElement | null }
+  | { type: "SET_CLASSES"; payload: string[] }
+  | { type: "TOGGLE_SECTION"; payload: string }
+  | { type: "SET_VALIDATION_ERRORS"; payload: Record<string, string[]> }
+  | { type: "SET_DIRTY"; payload: boolean }
+  | { type: "RESET_STATE" };

--- a/plugins/control-panel/ui/ControlPanel.css
+++ b/plugins/control-panel/ui/ControlPanel.css
@@ -524,3 +524,25 @@
 .action-btn.danger:hover {
   background: #dc2626;
 }
+
+/* Code editor toolbar (svg markup) aligns with existing action-btn styles */
+.code-toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.code-toolbar .action-btn {
+  padding: 6px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.code-toolbar .action-btn:hover {
+  background: var(--control-hover-bg);
+}

--- a/public/json-components/svg.json
+++ b/public/json-components/svg.json
@@ -23,11 +23,52 @@
   "integration": {
     "properties": {
       "schema": {
-        "viewBox": { "type": "string", "default": "0 0 900 500", "description": "SVG viewBox attribute" },
-        "preserveAspectRatio": { "type": "string", "default": "xMidYMid meet", "description": "SVG preserveAspectRatio attribute" },
-        "svgMarkup": { "type": "string", "default": "", "description": "Inner SVG markup to render (pasted contents)" }
+        "viewBox": {
+          "type": "string",
+          "default": "0 0 900 500",
+          "description": "SVG viewBox attribute"
+        },
+        "preserveAspectRatio": {
+          "type": "string",
+          "default": "xMidYMid meet",
+          "description": "SVG preserveAspectRatio attribute",
+          "enum": [
+            "none",
+            "xMinYMin meet",
+            "xMidYMin meet",
+            "xMaxYMin meet",
+            "xMinYMid meet",
+            "xMidYMid meet",
+            "xMaxYMid meet",
+            "xMinYMax meet",
+            "xMidYMax meet",
+            "xMaxYMax meet",
+            "xMinYMin slice",
+            "xMidYMin slice",
+            "xMaxYMin slice",
+            "xMinYMid slice",
+            "xMidYMid slice",
+            "xMaxYMid slice",
+            "xMinYMax slice",
+            "xMidYMax slice",
+            "xMaxYMax slice"
+          ]
+        },
+        "svgMarkup": {
+          "type": "string",
+          "default": "",
+          "description": "Inner SVG markup to render (pasted contents)",
+          "ui": {
+            "control": "code",
+            "rows": 8,
+            "placeholder": "Paste inner SVG markup or full <svg>…"
+          }
+        }
       },
-      "defaultValues": { "viewBox": "0 0 900 500", "preserveAspectRatio": "xMidYMid meet" }
+      "defaultValues": {
+        "viewBox": "0 0 900 500",
+        "preserveAspectRatio": "xMidYMid meet"
+      }
     },
     "canvasIntegration": {
       "resizable": true,
@@ -38,12 +79,29 @@
     }
   },
   "interactions": {
-    "canvas.component.create": { "pluginId": "CanvasComponentPlugin", "sequenceId": "canvas-component-create-symphony" },
-    "canvas.component.select": { "pluginId": "CanvasComponentSelectionPlugin", "sequenceId": "canvas-component-select-symphony" },
-    "canvas.component.drag.move": { "pluginId": "CanvasComponentDragPlugin", "sequenceId": "canvas-component-drag-symphony" },
-    "canvas.component.resize.start": { "pluginId": "CanvasComponentResizeStartPlugin", "sequenceId": "canvas-component-resize-start-symphony" },
-    "canvas.component.resize.move": { "pluginId": "CanvasComponentResizeMovePlugin", "sequenceId": "canvas-component-resize-move-symphony" },
-    "canvas.component.resize.end": { "pluginId": "CanvasComponentResizeEndPlugin", "sequenceId": "canvas-component-resize-end-symphony" }
+    "canvas.component.create": {
+      "pluginId": "CanvasComponentPlugin",
+      "sequenceId": "canvas-component-create-symphony"
+    },
+    "canvas.component.select": {
+      "pluginId": "CanvasComponentSelectionPlugin",
+      "sequenceId": "canvas-component-select-symphony"
+    },
+    "canvas.component.drag.move": {
+      "pluginId": "CanvasComponentDragPlugin",
+      "sequenceId": "canvas-component-drag-symphony"
+    },
+    "canvas.component.resize.start": {
+      "pluginId": "CanvasComponentResizeStartPlugin",
+      "sequenceId": "canvas-component-resize-start-symphony"
+    },
+    "canvas.component.resize.move": {
+      "pluginId": "CanvasComponentResizeMovePlugin",
+      "sequenceId": "canvas-component-resize-move-symphony"
+    },
+    "canvas.component.resize.end": {
+      "pluginId": "CanvasComponentResizeEndPlugin",
+      "sequenceId": "canvas-component-resize-end-symphony"
+    }
   }
 }
-

--- a/public/topics-manifest.json
+++ b/public/topics-manifest.json
@@ -637,7 +637,9 @@
       },
       "visibility": "public",
       "correlationKeys": [],
-      "perf": {},
+      "perf": {
+        "debounceMs": 250
+      },
       "notes": "Control panel field change requested; routes to field change sequence with throttling."
     },
     "control.panel.ui.field.validate.requested": {

--- a/topics-manifest.json
+++ b/topics-manifest.json
@@ -637,7 +637,9 @@
       },
       "visibility": "public",
       "correlationKeys": [],
-      "perf": {},
+      "perf": {
+        "debounceMs": 250
+      },
       "notes": "Control panel field change requested; routes to field change sequence with throttling."
     },
     "control.panel.ui.field.validate.requested": {


### PR DESCRIPTION
Implements Issue #85: Control Panel SVG Markup editor

Highlights:
- Code editor for Svg Markup field with Import (.svg), Format (XML pretty-print), and Full‑screen modal
- Paste/import detection for full <svg> → prompts to extract inner markup and apply viewBox/preserveAspectRatio via sequences
- preserveAspectRatio dropdown now includes all common presets (meet/slice + none)
- Debounced control.panel.ui.field.change.requested topic (250ms) to reduce chatter while typing
- SchemaResolver honors schema.ui.control = "code" and passes rendererProps
- New CodeTextarea renderer and CodeEditorModal; renderer wired in registry and PropertyFieldRenderer forwards selectedElement
- Styling: toolbar buttons aligned with Control Panel action-btn styles
- Test: svg.code-editor.mapping.spec validates mapping and enum presets

Notes:
- Follows repo sequencing: editors dispatch via conductor.play() via sequences
- No dependency changes

Please review. After approval, I can add additional tests for paste extraction and modal UX if desired.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author