### PR TITLE
fix(#99): Advanced Line — overlay alignment + handle drift + viewBox autosize

### DIFF
--- a/__tests__/canvas-component/advanced-line.augment.spec.ts
+++ b/__tests__/canvas-component/advanced-line.augment.spec.ts
@@ -1,0 +1,57 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+import { enhanceLine } from "../../plugins/canvas-component/symphonies/augment/augment.line.stage-crew";
+import {
+  setFlagOverride,
+  clearFlagOverrides,
+} from "../../src/feature-flags/flags";
+
+function makeSvgLineTemplate() {
+  return {
+    tag: "svg",
+    text: "",
+    classes: ["rx-comp", "rx-line"],
+    css: `.rx-line .segment { stroke: var(--stroke, #111827); stroke-width: var(--thickness, 2); }`,
+    cssVariables: { stroke: "#111827", thickness: 2 },
+    dimensions: { width: 120, height: 60 },
+  } as any;
+}
+
+function makeCtx() {
+  return { payload: {} } as any;
+}
+
+describe("Advanced Line augmentation (Phase 1)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="rx-canvas" style="position:relative"></div>';
+    setFlagOverride("lineAdvanced", true);
+  });
+  afterEach(() => {
+    clearFlagOverrides();
+  });
+
+  it("adds defs with markers exactly once (idempotent)", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgLineTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 10, y: 20 } } as any, ctx);
+
+    const svg = document.querySelector("#rx-canvas svg") as SVGSVGElement | null;
+    expect(svg).toBeTruthy();
+    // Before augment: no defs
+    expect(svg!.querySelector("defs#rx-line-markers")).toBeNull();
+
+    // Call augment
+    enhanceLine({}, ctx);
+    const first = svg!.querySelectorAll("defs#rx-line-markers");
+    expect(first.length).toBe(1);
+
+    // Call augment again -> still one defs
+    enhanceLine({}, ctx);
+    const second = svg!.querySelectorAll("defs#rx-line-markers");
+    expect(second.length).toBe(1);
+  });
+});
+

--- a/__tests__/canvas-component/advanced-line.manip.handlers.spec.ts
+++ b/__tests__/canvas-component/advanced-line.manip.handlers.spec.ts
@@ -1,0 +1,73 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+import { moveLineManip } from "../../plugins/canvas-component/symphonies/line-advanced/line.manip.stage-crew";
+import { recomputeLineSvg } from "../../plugins/canvas-component/symphonies/augment/line.recompute.stage-crew";
+import {
+  setFlagOverride,
+  clearFlagOverrides,
+} from "../../src/feature-flags/flags";
+
+function makeSvgLineTemplate() {
+  return {
+    tag: "svg",
+    text: "",
+    classes: ["rx-comp", "rx-line"],
+    css: `.rx-line .segment { stroke: var(--stroke, #111827); stroke-width: var(--thickness, 2); }`,
+    cssVariables: { stroke: "#111827", thickness: 2 },
+    dimensions: { width: 120, height: 60 },
+  } as any;
+}
+
+describe("Advanced Line handlers — moveLineManip", () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div id="rx-canvas" style="position:relative"></div>';
+    setFlagOverride("lineAdvanced", true);
+  });
+
+  it("updates endpoint A and recomputes line geometry", () => {
+    const ctx: any = { payload: {} };
+    const template = makeSvgLineTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector(
+      "#rx-canvas svg"
+    ) as SVGSVGElement | null;
+    expect(svg).toBeTruthy();
+    const id = (svg as any).getAttribute("id");
+
+    const host = svg as unknown as HTMLElement;
+    host.style.setProperty("--x1", "10");
+    host.style.setProperty("--y1", "10");
+    host.style.setProperty("--x2", "110");
+    host.style.setProperty("--y2", "50");
+
+    recomputeLineSvg(svg!);
+    const line = svg!.querySelector("line.segment") as SVGLineElement | null;
+    expect(line).toBeTruthy();
+    const x1Init = Number(line!.getAttribute("x1"));
+    const y1Init = Number(line!.getAttribute("y1"));
+    expect(x1Init).toBeGreaterThanOrEqual(8.2); // 10/120 * 100 ≈ 8.333
+    expect(x1Init).toBeLessThanOrEqual(8.4);
+    expect(y1Init).toBeGreaterThanOrEqual(16.6); // 10/60 * 100 ≈ 16.667
+    expect(y1Init).toBeLessThanOrEqual(16.8);
+
+    // Move A by (+10,+10)
+    moveLineManip({ id, handle: "a", dx: 10, dy: 10 });
+
+    const line2 = svg!.querySelector("line.segment") as SVGLineElement | null;
+    expect(line2).toBeTruthy();
+    // x1 should now reflect (20/120*100)=16.667
+    const x1 = Number(line2!.getAttribute("x1"));
+    const y1 = Number(line2!.getAttribute("y1"));
+    expect(x1).toBeGreaterThanOrEqual(16.5);
+    expect(x1).toBeLessThanOrEqual(16.8);
+    expect(y1).toBeGreaterThanOrEqual(33.2); // 20/60*100 ≈ 33.333
+    expect(y1).toBeLessThanOrEqual(33.5);
+
+    clearFlagOverrides();
+  });
+});

--- a/__tests__/canvas-component/advanced-line.overlay.attach.spec.ts
+++ b/__tests__/canvas-component/advanced-line.overlay.attach.spec.ts
@@ -1,0 +1,46 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+import { handlers as selectHandlers } from "../../plugins/canvas-component/symphonies/select/select.symphony";
+import { setFlagOverride, clearFlagOverrides } from "../../src/feature-flags/flags";
+
+function makeSvgLineTemplate() {
+  return {
+    tag: "svg",
+    text: "",
+    classes: ["rx-comp", "rx-line"],
+    css: `.rx-line .segment { stroke: var(--stroke, #111827); stroke-width: var(--thickness, 2); }`,
+    cssVariables: { stroke: "#111827", thickness: 2 },
+    dimensions: { width: 120, height: 60 },
+  } as any;
+}
+
+describe("Advanced Line overlay attaches on selection (flag ON)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="rx-canvas" style="position:relative"></div>';
+    setFlagOverride("lineAdvanced", true);
+  });
+
+  it("creates #rx-adv-line-overlay and binds dataset targetId", () => {
+    const ctx: any = { payload: {} };
+    const template = makeSvgLineTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector("#rx-canvas svg") as SVGSVGElement | null;
+    expect(svg).toBeTruthy();
+
+    const id = (svg as any).getAttribute("id");
+    expect(id).toBeTruthy();
+
+    selectHandlers.showSelectionOverlay({ id }, { conductor: { play() {} } });
+
+    const adv = document.getElementById("rx-adv-line-overlay") as HTMLDivElement | null;
+    expect(adv).toBeTruthy();
+    expect(adv!.dataset.targetId).toBe(String(id));
+
+    clearFlagOverrides();
+  });
+});
+

--- a/__tests__/canvas-component/advanced-line.overlay.drag.spec.ts
+++ b/__tests__/canvas-component/advanced-line.overlay.drag.spec.ts
@@ -1,0 +1,105 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+import { handlers as selectHandlers } from "../../plugins/canvas-component/symphonies/select/select.symphony";
+import { recomputeLineSvg } from "../../plugins/canvas-component/symphonies/augment/line.recompute.stage-crew";
+import {
+  setFlagOverride,
+  clearFlagOverrides,
+} from "../../src/feature-flags/flags";
+
+function makeSvgLineTemplate() {
+  return {
+    tag: "svg",
+    text: "",
+    classes: ["rx-comp", "rx-line"],
+    css: `.rx-line .segment { stroke: var(--stroke, #111827); stroke-width: var(--thickness, 2); }`,
+    cssVariables: { stroke: "#111827", thickness: 2 },
+    dimensions: { width: 120, height: 60 },
+  } as any;
+}
+
+// This test reproduces the bug: overlay sends cumulative dx,dy per mousemove, but the handler
+// adds dx,dy to the already-updated base each time, causing runaway drift (overextension/over-rotation).
+// Expected: after two moves to (+4,+4) then (+10,+10) from the same start, the final endpoint delta
+// should be exactly (+10,+10) relative to the initial position, not (+14,+14).
+
+describe("Advanced Line overlay drag — cumulative delta causes runaway (expected failing)", () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div id="rx-canvas" style="position:relative"></div>';
+    setFlagOverride("lineAdvanced", true);
+  });
+
+  it("dragging endpoint A twice with cumulative deltas should not over-accumulate", async () => {
+    const ctx: any = { payload: {} };
+    const template = makeSvgLineTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector(
+      "#rx-canvas svg"
+    ) as SVGSVGElement | null;
+    expect(svg).toBeTruthy();
+    const id = (svg as any).getAttribute("id");
+
+    const host = svg as unknown as HTMLElement;
+    // Initial endpoints: (10,10) -> (110,50)
+    host.style.setProperty("--x1", "10");
+    host.style.setProperty("--y1", "10");
+    host.style.setProperty("--x2", "110");
+    host.style.setProperty("--y2", "50");
+
+    // Initial geometry
+    recomputeLineSvg(svg!);
+
+    // Attach advanced overlay for this selection
+    // Intentionally omit conductor to force fallback path in overlay handler
+    selectHandlers.showSelectionOverlay({ id });
+
+    const overlay = document.getElementById(
+      "rx-adv-line-overlay"
+    ) as HTMLDivElement | null;
+    expect(overlay).toBeTruthy();
+    const handleA = overlay!.querySelector(
+      ".handle.a"
+    ) as HTMLDivElement | null;
+    expect(handleA).toBeTruthy();
+
+    // Simulate mousedown at arbitrary start
+    handleA!.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, clientX: 100, clientY: 100 })
+    );
+
+    // First mousemove: +4,+4 from start => dx=4,dy=4
+    document.dispatchEvent(
+      new MouseEvent("mousemove", { bubbles: true, clientX: 104, clientY: 104 })
+    );
+
+    // Second mousemove: +10,+10 from start => dx=10,dy=10 (cumulative)
+    document.dispatchEvent(
+      new MouseEvent("mousemove", { bubbles: true, clientX: 110, clientY: 110 })
+    );
+
+    // End drag
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    // Inspect final line attributes
+    const line = svg!.querySelector("line.segment") as SVGLineElement | null;
+    expect(line).toBeTruthy();
+
+    // Expected position for x1,y1: (10+10, 10+10) => (20, 20)
+    // In viewBox units: x: 20/120*100 ≈ 16.667, y: 20/60*100 ≈ 33.333
+    const x1 = Number(line!.getAttribute("x1"));
+    const y1 = Number(line!.getAttribute("y1"));
+
+    // This currently fails because compounding produces 24/120*100=20 and 24/60*100=40
+    expect(x1).toBeGreaterThanOrEqual(16.6);
+    expect(x1).toBeLessThanOrEqual(16.8);
+    expect(y1).toBeGreaterThanOrEqual(33.2);
+    expect(y1).toBeLessThanOrEqual(33.5);
+
+    clearFlagOverrides();
+  });
+});

--- a/__tests__/canvas-component/advanced-line.recompute.spec.ts
+++ b/__tests__/canvas-component/advanced-line.recompute.spec.ts
@@ -1,0 +1,147 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+import { enhanceLine } from "../../plugins/canvas-component/symphonies/augment/augment.line.stage-crew";
+import { recomputeLineSvg } from "../../plugins/canvas-component/symphonies/augment/line.recompute.stage-crew";
+import {
+  setFlagOverride,
+  clearFlagOverrides,
+} from "../../src/feature-flags/flags";
+
+function makeSvgLineTemplate() {
+  return {
+    tag: "svg",
+    text: "",
+    classes: ["rx-comp", "rx-line"],
+    css: `.rx-line .segment, .rx-line .segment-curve { stroke: var(--stroke, #111827); stroke-width: var(--thickness, 2); fill: none; }`,
+    cssVariables: { stroke: "#111827", thickness: 2 },
+    dimensions: { width: 120, height: 60 },
+  } as any;
+}
+
+function makeCtx() {
+  return { payload: {} } as any;
+}
+
+describe("Advanced Line recompute (Phase 2+3)", () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div id="rx-canvas" style="position:relative"></div>';
+    setFlagOverride("lineAdvanced", true);
+  });
+
+  it("maps CSS vars to line x1/y1/x2/y2 in viewBox coordinates", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgLineTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 10, y: 20 } } as any, ctx);
+
+    const svg = document.querySelector(
+      "#rx-canvas svg"
+    ) as SVGSVGElement | null;
+    expect(svg).toBeTruthy();
+
+    // Augment (adds defs markers; not strictly needed for recompute)
+    enhanceLine({}, ctx);
+
+    const host = svg as unknown as HTMLElement;
+    // Host sized by createNode to 120x60
+    expect(host.style.width).toBe("120px");
+    expect(host.style.height).toBe("60px");
+
+    // Set endpoints in px coordinates relative to host size
+    host.style.setProperty("--x1", "0");
+    host.style.setProperty("--y1", "30"); // middle of height (60)
+    host.style.setProperty("--x2", "120"); // full width
+    host.style.setProperty("--y2", "30");
+
+    recomputeLineSvg(svg!);
+
+    const line = svg!.querySelector("line.segment") as SVGLineElement | null;
+    expect(line).toBeTruthy();
+
+    // Expect 0,50 to 100,50 (scaled into 0..100 viewBox)
+    expect(line!.getAttribute("x1")).toBe("0");
+    expect(line!.getAttribute("y1")).toBe("50");
+    expect(line!.getAttribute("x2")).toBe("100");
+    expect(line!.getAttribute("y2")).toBe("50");
+  });
+
+  it("toggles marker-end via --arrowEnd CSS var", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgLineTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector("#rx-canvas svg") as SVGSVGElement;
+    const host = svg as unknown as HTMLElement;
+
+    // off by default
+    recomputeLineSvg(svg);
+    let line = svg.querySelector("line.segment") as SVGLineElement;
+    expect(line.getAttribute("marker-end")).toBe(null);
+
+    host.style.setProperty("--arrowEnd", "1");
+    recomputeLineSvg(svg);
+    line = svg.querySelector("line.segment") as SVGLineElement;
+    expect(line.getAttribute("marker-end")).toBe("url(#rx-arrow-end)");
+
+    host.style.setProperty("--arrowEnd", "0");
+    recomputeLineSvg(svg);
+    line = svg.querySelector("line.segment") as SVGLineElement;
+    expect(line.getAttribute("marker-end")).toBe(null);
+
+    clearFlagOverrides();
+  });
+
+  it("renders quadratic path when --curve=1 with --cx/--cy", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgLineTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector("#rx-canvas svg") as SVGSVGElement;
+    const host = svg as unknown as HTMLElement;
+
+    host.style.setProperty("--x1", "0");
+    host.style.setProperty("--y1", "30");
+    host.style.setProperty("--x2", "120");
+    host.style.setProperty("--y2", "30");
+    host.style.setProperty("--cx", "60");
+    host.style.setProperty("--cy", "10");
+    host.style.setProperty("--curve", "1");
+
+    recomputeLineSvg(svg);
+
+    const line = svg.querySelector("line.segment") as SVGLineElement;
+    const path = svg.querySelector("path.segment-curve") as SVGPathElement;
+    expect(line.style.display || "").toBe("none");
+    expect(path).toBeTruthy();
+    expect(path.getAttribute("d") || "").toMatch(/^M\s*0\s*50\s*Q\s*50/); // rough check: contains a Q command
+  });
+
+  it("applies rotate transform when --angle is set", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgLineTemplate();
+
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector("#rx-canvas svg") as SVGSVGElement;
+    const host = svg as unknown as HTMLElement;
+
+    host.style.setProperty("--x1", "0");
+    host.style.setProperty("--y1", "30");
+    host.style.setProperty("--x2", "120");
+    host.style.setProperty("--y2", "30");
+    host.style.setProperty("--angle", "45");
+
+    recomputeLineSvg(svg);
+
+    const line = svg.querySelector("line.segment") as SVGLineElement;
+    expect(line.getAttribute("transform") || "").toContain("rotate(45");
+  });
+});

--- a/__tests__/canvas-component/advanced-line.resize.scale.spec.ts
+++ b/__tests__/canvas-component/advanced-line.resize.scale.spec.ts
@@ -1,0 +1,92 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+import { handlers as resizeHandlers } from "../../plugins/canvas-component/symphonies/resize/resize.symphony";
+import { recomputeLineSvg } from "../../plugins/canvas-component/symphonies/augment/line.recompute.stage-crew";
+
+function makeSvgLineTemplate() {
+  return {
+    tag: "svg",
+    text: "",
+    classes: ["rx-comp", "rx-line"],
+    css: `.rx-line .segment { stroke: var(--stroke, #111827); stroke-width: var(--thickness, 2); }`,
+    cssVariables: { stroke: "#111827", thickness: 2 },
+    dimensions: { width: 120, height: 60 },
+  } as any;
+}
+
+function makeCtx() {
+  return { payload: {} } as any;
+}
+
+describe("Advanced Line — endpoints scale with resize", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="rx-canvas" style="position:relative"></div>';
+  });
+
+  it("proportionally scales --x1/--y1/--x2/--y2 when resizing the element", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgLineTemplate();
+
+    // Create element
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 10, y: 20 } } as any, ctx);
+
+    const id = ctx.payload.nodeId as string;
+    const el = document.getElementById(id)! as HTMLElement;
+    const svg = el as unknown as SVGSVGElement;
+
+    // Seed endpoints (px in element space)
+    el.style.setProperty("--x1", "10");
+    el.style.setProperty("--y1", "10");
+    el.style.setProperty("--x2", "110");
+    el.style.setProperty("--y2", "50");
+
+    // Initial recompute => establishes baseline attributes
+    recomputeLineSvg(svg);
+    const line1 = svg.querySelector("line.segment") as SVGLineElement;
+    const x2AttrInitial = parseFloat(line1.getAttribute("x2") || "0");
+
+    // Begin resize and move SE inward by half width/height (shrink)
+    const startLeft = 10;
+    const startTop = 20;
+    const startWidth = 120;
+    const startHeight = 60;
+
+    resizeHandlers.startResize?.({ id });
+    resizeHandlers.updateSize?.(
+      {
+        id,
+        dir: "se",
+        startLeft,
+        startTop,
+        startWidth,
+        startHeight,
+        dx: -60, // new width = 60
+        dy: -30, // new height = 30
+        phase: "move",
+      },
+      {} as any
+    );
+
+    // Endpoints should have been scaled by 0.5
+    const x1 = parseFloat(el.style.getPropertyValue("--x1"));
+    const y1 = parseFloat(el.style.getPropertyValue("--y1"));
+    const x2 = parseFloat(el.style.getPropertyValue("--x2"));
+    const y2 = parseFloat(el.style.getPropertyValue("--y2"));
+
+    expect(x1).toBeCloseTo(5, 5);
+    expect(y1).toBeCloseTo(5, 5);
+    expect(x2).toBeCloseTo(55, 5);
+    expect(y2).toBeCloseTo(25, 5);
+
+    // After recompute, relative percentages should be preserved
+    recomputeLineSvg(svg);
+    const line2 = svg.querySelector("line.segment") as SVGLineElement;
+    const x2AttrNext = parseFloat(line2.getAttribute("x2") || "0");
+
+    // The percentage of x2 in viewBox should remain the same
+    expect(x2AttrNext).toBeCloseTo(x2AttrInitial, 5);
+  });
+});
+

--- a/__tests__/canvas-component/advanced-line.viewbox.autosize.spec.ts
+++ b/__tests__/canvas-component/advanced-line.viewbox.autosize.spec.ts
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach } from "vitest";
+import { handlers as createHandlers } from "../../plugins/canvas-component/symphonies/create/create.symphony";
+import { recomputeLineSvg } from "../../plugins/canvas-component/symphonies/augment/line.recompute.stage-crew";
+
+function makeSvgLineTemplate() {
+  return {
+    tag: "svg",
+    text: "",
+    classes: ["rx-comp", "rx-line"],
+    css: `.rx-line .segment { stroke: var(--stroke, #111827); stroke-width: var(--thickness, 2); }`,
+    cssVariables: { stroke: "#111827", thickness: 2 },
+    dimensions: { width: 120, height: 60 },
+  } as any;
+}
+
+function makeCtx() {
+  return { payload: {} } as any;
+}
+
+describe("Advanced Line — dynamic viewBox autosize", () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div id="rx-canvas" style="position:relative"></div>';
+  });
+
+  it("expands viewBox when endpoints extend beyond element bounds (no rotation)", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgLineTemplate();
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector("#rx-canvas svg") as SVGSVGElement;
+    const host = svg as unknown as HTMLElement;
+
+    // Host size 120x60; set endpoints outside in px
+    host.style.setProperty("--x1", "-20");
+    host.style.setProperty("--y1", "10");
+    host.style.setProperty("--x2", "180"); // 60px beyond width
+    host.style.setProperty("--y2", "50");
+
+    recomputeLineSvg(svg);
+
+    const vb = (svg.getAttribute("viewBox") || "0 0 100 100")
+      .split(/\s+/)
+      .map(parseFloat);
+    const [minX, , vbW] = vb;
+
+    // In normalized units: x1=-16.67, x2=150. Expect viewBox to cover this range
+    expect(minX).toBeLessThanOrEqual(-10);
+    expect(vbW).toBeGreaterThan(100); // width grew beyond default
+  });
+
+  it("adds headroom when rotated so the line is never clipped", () => {
+    const ctx: any = makeCtx();
+    const template = makeSvgLineTemplate();
+    createHandlers.resolveTemplate({ component: { template } } as any, ctx);
+    createHandlers.createNode({ position: { x: 0, y: 0 } } as any, ctx);
+
+    const svg = document.querySelector("#rx-canvas svg") as SVGSVGElement;
+    const host = svg as unknown as HTMLElement;
+
+    // Long line beyond width and rotated 45deg
+    host.style.setProperty("--x1", "0");
+    host.style.setProperty("--y1", "30");
+    host.style.setProperty("--x2", "180");
+    host.style.setProperty("--y2", "30");
+    host.style.setProperty("--angle", "45");
+
+    recomputeLineSvg(svg);
+
+    const vb = (svg.getAttribute("viewBox") || "0 0 100 100")
+      .split(/\s+/)
+      .map(parseFloat);
+    const [, , vbW, vbH] = vb;
+
+    // Expect larger bounds than the default 100x100 due to over-extent + rotation
+    expect(vbW).toBeGreaterThan(100);
+    expect(vbH).toBeGreaterThan(100);
+  });
+});

--- a/data/feature-flags.json
+++ b/data/feature-flags.json
@@ -108,5 +108,11 @@
     "created": "2025-09-05",
     "description": "Enable experimental Rich HTML component (sanitized pasted markup)",
     "owner": "library"
+  },
+  "lineAdvanced": {
+    "status": "on",
+    "created": "2025-09-06",
+    "description": "Enable Advanced Line augmentation & overlay (Issue #99)",
+    "owner": "canvas"
   }
 }

--- a/json-sequences/canvas-component/create.json
+++ b/json-sequences/canvas-component/create.json
@@ -7,12 +7,52 @@
       "id": "create",
       "name": "Create",
       "beats": [
-        { "beat": 1, "event": "canvas:component:resolve-template", "title": "Resolve Template", "dynamics": "mf", "handler": "resolveTemplate", "timing": "immediate", "kind": "pure" },
-        { "beat": 2, "event": "canvas:component:register-instance", "title": "Register Instance", "dynamics": "mf", "handler": "registerInstance", "timing": "immediate", "kind": "io" },
-        { "beat": 3, "event": "canvas:component:create", "title": "Create Node", "dynamics": "mf", "handler": "createNode", "timing": "immediate", "kind": "stage-crew" },
-        { "beat": 4, "event": "canvas:component:notify-ui", "title": "Notify UI", "dynamics": "mf", "handler": "notifyUi", "timing": "immediate", "kind": "pure" }
+        {
+          "beat": 1,
+          "event": "canvas:component:resolve-template",
+          "title": "Resolve Template",
+          "dynamics": "mf",
+          "handler": "resolveTemplate",
+          "timing": "immediate",
+          "kind": "pure"
+        },
+        {
+          "beat": 2,
+          "event": "canvas:component:register-instance",
+          "title": "Register Instance",
+          "dynamics": "mf",
+          "handler": "registerInstance",
+          "timing": "immediate",
+          "kind": "io"
+        },
+        {
+          "beat": 3,
+          "event": "canvas:component:create",
+          "title": "Create Node",
+          "dynamics": "mf",
+          "handler": "createNode",
+          "timing": "immediate",
+          "kind": "stage-crew"
+        },
+        {
+          "beat": 4,
+          "event": "canvas:component:notify-ui",
+          "title": "Notify UI",
+          "dynamics": "mf",
+          "handler": "notifyUi",
+          "timing": "immediate",
+          "kind": "pure"
+        },
+        {
+          "beat": 5,
+          "event": "canvas:component:augment:line",
+          "title": "Enhance Line (Advanced)",
+          "dynamics": "mf",
+          "handler": "enhanceLine",
+          "timing": "immediate",
+          "kind": "stage-crew"
+        }
       ]
     }
   ]
 }
-

--- a/json-sequences/canvas-component/line.manip.end.json
+++ b/json-sequences/canvas-component/line.manip.end.json
@@ -1,0 +1,15 @@
+{
+  "pluginId": "CanvasLineManipEndPlugin",
+  "id": "canvas-line-manip-end-symphony",
+  "name": "Canvas Line Manip End",
+  "movements": [
+    {
+      "id": "manip-line-end",
+      "name": "Manip Line End",
+      "beats": [
+        { "beat": 1, "event": "canvas:component:manip:line:end", "title": "Line Manip End", "dynamics": "mf", "handler": "endLineManip", "timing": "immediate", "kind": "stage-crew" }
+      ]
+    }
+  ]
+}
+

--- a/json-sequences/canvas-component/line.manip.move.json
+++ b/json-sequences/canvas-component/line.manip.move.json
@@ -1,0 +1,15 @@
+{
+  "pluginId": "CanvasLineManipMovePlugin",
+  "id": "canvas-line-manip-move-symphony",
+  "name": "Canvas Line Manip Move",
+  "movements": [
+    {
+      "id": "manip-line-move",
+      "name": "Manip Line Move",
+      "beats": [
+        { "beat": 1, "event": "canvas:component:manip:line:move", "title": "Line Manip Move", "dynamics": "mf", "handler": "moveLineManip", "timing": "immediate", "kind": "stage-crew" }
+      ]
+    }
+  ]
+}
+

--- a/json-sequences/canvas-component/line.manip.start.json
+++ b/json-sequences/canvas-component/line.manip.start.json
@@ -1,0 +1,15 @@
+{
+  "pluginId": "CanvasLineManipStartPlugin",
+  "id": "canvas-line-manip-start-symphony",
+  "name": "Canvas Line Manip Start",
+  "movements": [
+    {
+      "id": "manip-line-start",
+      "name": "Manip Line Start",
+      "beats": [
+        { "beat": 1, "event": "canvas:component:manip:line:start", "title": "Line Manip Start", "dynamics": "mf", "handler": "startLineManip", "timing": "immediate", "kind": "stage-crew" }
+      ]
+    }
+  ]
+}
+

--- a/plugins/canvas-component/symphonies/augment/augment.line.stage-crew.ts
+++ b/plugins/canvas-component/symphonies/augment/augment.line.stage-crew.ts
@@ -1,0 +1,53 @@
+import { isFlagEnabled } from "../../../../src/feature-flags/flags";
+
+// Add basic SVG defs (arrow markers). Keep minimal; more will be added in later phases.
+function ensureLineMarkers(svg: SVGSVGElement) {
+  const ns = "http://www.w3.org/2000/svg";
+  let defs = svg.querySelector("defs#rx-line-markers") as SVGDefsElement | null;
+  if (!defs) {
+    defs = document.createElementNS(ns, "defs") as SVGDefsElement;
+    defs.id = "rx-line-markers";
+
+    // Minimal example marker. In future phases, we will add start/end variants and styling.
+    const markerEnd = document.createElementNS(ns, "marker");
+    markerEnd.setAttribute("id", "rx-arrow-end");
+    markerEnd.setAttribute("markerWidth", "6");
+    markerEnd.setAttribute("markerHeight", "6");
+    markerEnd.setAttribute("refX", "5");
+    markerEnd.setAttribute("refY", "3");
+    markerEnd.setAttribute("orient", "auto");
+
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", "M0,0 L6,3 L0,6 Z");
+    path.setAttribute("fill", "currentColor");
+    markerEnd.appendChild(path);
+
+    defs.appendChild(markerEnd);
+    svg.appendChild(defs);
+  }
+}
+
+export function enhanceLine(_data: any, ctx: any) {
+  try {
+    if (!isFlagEnabled("lineAdvanced")) return;
+    const id = ctx?.payload?.nodeId;
+    if (!id) return;
+    const el = document.getElementById(String(id));
+    if (!el) return;
+    if (!(el instanceof SVGSVGElement)) return;
+    if (!el.classList.contains("rx-line")) return;
+
+    // Ensure base SVG attributes are present (idempotent)
+    el.setAttribute("width", el.getAttribute("width") || "100%");
+    el.setAttribute("height", el.getAttribute("height") || "100%");
+    el.setAttribute("viewBox", el.getAttribute("viewBox") || "0 0 100 100");
+    el.setAttribute(
+      "preserveAspectRatio",
+      el.getAttribute("preserveAspectRatio") || "none"
+    );
+
+    // Phase 1: add defs (markers) once. Idempotent if already present.
+    ensureLineMarkers(el);
+  } catch {}
+}
+

--- a/plugins/canvas-component/symphonies/augment/line.recompute.stage-crew.ts
+++ b/plugins/canvas-component/symphonies/augment/line.recompute.stage-crew.ts
@@ -1,0 +1,205 @@
+// Phase 2+3: Recompute SVG geometry for line based on CSS variables on the host element
+// Idempotent and side-effect free beyond DOM attribute updates on child nodes.
+
+const NS = "http://www.w3.org/2000/svg";
+
+function ensureLine(svg: SVGSVGElement): SVGLineElement {
+  let line = svg.querySelector("line.segment") as SVGLineElement | null;
+  if (!line) {
+    line = document.createElementNS(NS, "line") as SVGLineElement;
+    line.setAttribute("class", "segment");
+    line.setAttribute("vector-effect", "non-scaling-stroke");
+    svg.appendChild(line);
+  }
+  return line;
+}
+
+function ensureCurve(svg: SVGSVGElement): SVGPathElement {
+  let path = svg.querySelector("path.segment-curve") as SVGPathElement | null;
+  if (!path) {
+    path = document.createElementNS(NS, "path") as SVGPathElement;
+    path.setAttribute("class", "segment-curve");
+    path.setAttribute("vector-effect", "non-scaling-stroke");
+    path.style.display = "none"; // hidden unless curve enabled
+    svg.appendChild(path);
+  }
+  return path;
+}
+
+function readCssNumber(
+  el: HTMLElement,
+  name: string,
+  fallback: number
+): number {
+  // Prefer inline style, fallback to computed style
+  const inline = el.style.getPropertyValue(name);
+  if (inline) {
+    const n = parseFloat(inline);
+    if (Number.isFinite(n)) return n;
+  }
+  try {
+    const cs = getComputedStyle(el);
+    const v = cs.getPropertyValue(name);
+    const n = parseFloat(v);
+    if (Number.isFinite(n)) return n;
+  } catch {}
+  return fallback;
+}
+
+function readBooleanVar(el: HTMLElement, name: string): boolean {
+  const v = (el.style.getPropertyValue(name) || "").trim().toLowerCase();
+  if (v === "1" || v === "true" || v === "yes") return true;
+  if (v === "0" || v === "false" || v === "no") return false;
+  // Try computed style as string
+  try {
+    const cs = getComputedStyle(el);
+    const c = (cs.getPropertyValue(name) || "").trim().toLowerCase();
+    if (c === "1" || c === "true" || c === "yes") return true;
+    if (c === "0" || c === "false" || c === "no") return false;
+  } catch {}
+  return false;
+}
+
+function resolveSize(svg: SVGSVGElement): { w: number; h: number } {
+  // Prefer inline style width/height (set by create.stage-crew)
+  const wStr = (svg as unknown as HTMLElement).style.width || "";
+  const hStr = (svg as unknown as HTMLElement).style.height || "";
+  const w = parseFloat(wStr) || svg.getBoundingClientRect?.().width || 0 || 100;
+  const h =
+    parseFloat(hStr) || svg.getBoundingClientRect?.().height || 0 || 100;
+  return { w: w || 100, h: h || 100 };
+}
+
+export function recomputeLineSvg(svg: SVGSVGElement) {
+  const host = svg as unknown as HTMLElement;
+  const line = ensureLine(svg);
+  const curve = ensureCurve(svg);
+
+  const { w, h } = resolveSize(svg);
+
+  // Defaults: x1=0, y1=0, x2=w, y2=y1 to keep horizontal by default
+  const x1 = readCssNumber(host, "--x1", 0);
+  const y1 = readCssNumber(host, "--y1", 0);
+  const x2 = readCssNumber(host, "--x2", w);
+  const y2 = readCssNumber(host, "--y2", y1);
+
+  // Optional curvature and rotation
+  const cx = readCssNumber(host, "--cx", (x1 + x2) / 2);
+  const cy = readCssNumber(host, "--cy", (y1 + y2) / 2);
+  const curveOn = readBooleanVar(host, "--curve");
+  const angle = readCssNumber(host, "--angle", 0); // degrees
+
+  const toVbX = (px: number) =>
+    Number(
+      (w ? (px / w) * 100 : 0)
+        .toFixed(3)
+        .replace(/\.0+$/, "")
+        .replace(/\.$/, "")
+    );
+  const toVbY = (px: number) =>
+    Number(
+      (h ? (px / h) * 100 : 0)
+        .toFixed(3)
+        .replace(/\.0+$/, "")
+        .replace(/\.$/, "")
+    );
+
+  const nx1 = toVbX(x1);
+  const ny1 = toVbY(y1);
+  const nx2 = toVbX(x2);
+  const ny2 = toVbY(y2);
+  const ncx = toVbX(cx);
+  const ncy = toVbY(cy);
+
+  const setRotate = (elt: SVGElement) => {
+    if (!elt) return;
+    if (Math.abs(angle) > 0.0001) {
+      // rotate around midpoint of endpoints in viewBox units
+      const mx = (nx1 + nx2) / 2;
+      const my = (ny1 + ny2) / 2;
+      elt.setAttribute("transform", `rotate(${angle} ${mx} ${my})`);
+    } else {
+      elt.removeAttribute("transform");
+    }
+  };
+
+  // --- Dynamic viewBox autosize to prevent clipping when endpoints extend or rotate ---
+  const thickness = readCssNumber(host, "--thickness", 2);
+  const padX = ((thickness * 4) / (w || 1)) * 100; // generous padding in percent
+  const padY = ((thickness * 4) / (h || 1)) * 100;
+
+  const rad = (angle * Math.PI) / 180;
+  const mx = (nx1 + nx2) / 2;
+  const my = (ny1 + ny2) / 2;
+  const rotatePoint = (x: number, y: number) => {
+    if (!rad) return { x, y };
+    const cos = Math.cos(rad);
+    const sin = Math.sin(rad);
+    const dx = x - mx;
+    const dy = y - my;
+    return { x: mx + dx * cos - dy * sin, y: my + dx * sin + dy * cos };
+  };
+
+  const p1r = rotatePoint(nx1, ny1);
+  const p2r = rotatePoint(nx2, ny2);
+  // If curved, include control point as a rough bound
+  const cr = rotatePoint(ncx, ncy);
+
+  let minX = Math.min(nx1, nx2, p1r.x, p2r.x, curveOn ? cr.x : nx1);
+  let minY = Math.min(ny1, ny2, p1r.y, p2r.y, curveOn ? cr.y : ny1);
+  let maxX = Math.max(nx1, nx2, p1r.x, p2r.x, curveOn ? cr.x : nx2);
+  let maxY = Math.max(ny1, ny2, p1r.y, p2r.y, curveOn ? cr.y : ny2);
+
+  minX -= padX;
+  minY -= padY;
+  maxX += padX;
+  maxY += padY;
+
+  const vbW = Math.max(1, maxX - minX);
+  const vbH = Math.max(1, maxY - minY);
+  svg.setAttribute(
+    "viewBox",
+    `${minX.toFixed(3).replace(/\.0+$/, "").replace(/\.$/, "")} ${minY
+      .toFixed(3)
+      .replace(/\.0+$/, "")
+      .replace(/\.$/, "")} ${vbW
+      .toFixed(3)
+      .replace(/\.0+$/, "")
+      .replace(/\.$/, "")} ${vbH
+      .toFixed(3)
+      .replace(/\.0+$/, "")
+      .replace(/\.$/, "")}`
+  );
+
+  if (curveOn) {
+    // Use quadratic Bezier through control point (cx, cy) in normalized coords
+    const d = `M ${nx1} ${ny1} Q ${ncx} ${ncy} ${nx2} ${ny2}`;
+    curve.setAttribute("d", d);
+    curve.style.display = "";
+    line.style.display = "none";
+    // Arrow toggles on curve path
+    const arrowStart = readBooleanVar(host, "--arrowStart");
+    const arrowEnd = readBooleanVar(host, "--arrowEnd");
+    if (arrowStart) curve.setAttribute("marker-start", "url(#rx-arrow-start)");
+    else curve.removeAttribute("marker-start");
+    if (arrowEnd) curve.setAttribute("marker-end", "url(#rx-arrow-end)");
+    else curve.removeAttribute("marker-end");
+    setRotate(curve);
+  } else {
+    // Straight line
+    line.setAttribute("x1", String(nx1));
+    line.setAttribute("y1", String(ny1));
+    line.setAttribute("x2", String(nx2));
+    line.setAttribute("y2", String(ny2));
+    curve.style.display = "none";
+    line.style.display = "";
+    // Arrow toggles on line
+    const arrowStart = readBooleanVar(host, "--arrowStart");
+    const arrowEnd = readBooleanVar(host, "--arrowEnd");
+    if (arrowStart) line.setAttribute("marker-start", "url(#rx-arrow-start)");
+    else line.removeAttribute("marker-start");
+    if (arrowEnd) line.setAttribute("marker-end", "url(#rx-arrow-end)");
+    else line.removeAttribute("marker-end");
+    setRotate(line);
+  }
+}

--- a/plugins/canvas-component/symphonies/create/create.symphony.ts
+++ b/plugins/canvas-component/symphonies/create/create.symphony.ts
@@ -2,6 +2,7 @@ import { resolveTemplate } from "./create.arrangement";
 import { registerInstance } from "./create.io";
 import { createNode } from "./create.stage-crew";
 import { notifyUi } from "./create.notify";
+import { enhanceLine } from "../augment/augment.line.stage-crew";
 
 // NOTE: Runtime sequences are mounted from JSON (see json-sequences/*). This file only exports handlers.
 
@@ -10,4 +11,5 @@ export const handlers = {
   registerInstance,
   createNode,
   notifyUi,
+  enhanceLine,
 };

--- a/plugins/canvas-component/symphonies/line-advanced/line.manip.end.symphony.ts
+++ b/plugins/canvas-component/symphonies/line-advanced/line.manip.end.symphony.ts
@@ -1,0 +1,4 @@
+import { endLineManip } from "./line.manip.stage-crew";
+
+export const handlers = { endLineManip };
+

--- a/plugins/canvas-component/symphonies/line-advanced/line.manip.move.symphony.ts
+++ b/plugins/canvas-component/symphonies/line-advanced/line.manip.move.symphony.ts
@@ -1,0 +1,4 @@
+import { moveLineManip } from "./line.manip.stage-crew";
+
+export const handlers = { moveLineManip };
+

--- a/plugins/canvas-component/symphonies/line-advanced/line.manip.stage-crew.ts
+++ b/plugins/canvas-component/symphonies/line-advanced/line.manip.stage-crew.ts
@@ -1,0 +1,71 @@
+import { recomputeLineSvg } from "../augment/line.recompute.stage-crew";
+
+function updateEndpoint(
+  host: HTMLElement,
+  handle: "a" | "b",
+  dx: number,
+  dy: number
+) {
+  const isA = handle === "a";
+  const xVar = isA ? "--x1" : "--x2";
+  const yVar = isA ? "--y1" : "--y2";
+  const baseX = parseFloat(host.style.getPropertyValue(xVar) || "0");
+  const baseY = parseFloat(host.style.getPropertyValue(yVar) || "0");
+  const nx = Math.round(baseX + (dx || 0));
+  const ny = Math.round(baseY + (dy || 0));
+  host.style.setProperty(xVar, `${nx}`);
+  host.style.setProperty(yVar, `${ny}`);
+}
+
+function updateCurve(host: HTMLElement, dx: number, dy: number) {
+  const x1 = parseFloat(host.style.getPropertyValue("--x1") || "0");
+  const y1 = parseFloat(host.style.getPropertyValue("--y1") || "0");
+  const x2 = parseFloat(host.style.getPropertyValue("--x2") || "0");
+  const y2 = parseFloat(host.style.getPropertyValue("--y2") || String(y1));
+  const baseCX = parseFloat(
+    host.style.getPropertyValue("--cx") || String((x1 + x2) / 2)
+  );
+  const baseCY = parseFloat(
+    host.style.getPropertyValue("--cy") || String((y1 + y2) / 2)
+  );
+  const ncx = Math.round(baseCX + (dx || 0));
+  const ncy = Math.round(baseCY + (dy || 0));
+  host.style.setProperty("--cx", `${ncx}`);
+  host.style.setProperty("--cy", `${ncy}`);
+  host.style.setProperty("--curve", "1");
+}
+
+function updateRotate(host: HTMLElement, dx: number) {
+  const baseAngle = parseFloat(host.style.getPropertyValue("--angle") || "0");
+  const next = Math.round(baseAngle + (dx || 0));
+  host.style.setProperty("--angle", `${next}`);
+}
+
+export function startLineManip(data: any) {
+  // For future use (e.g., snapshot for undo). No-op for now.
+  return data;
+}
+
+export function moveLineManip(data: any) {
+  try {
+    const { id, handle, dx = 0, dy = 0 } = data || {};
+    if (!id) return;
+    const el = document.getElementById(String(id)) as SVGSVGElement | null;
+    if (!el) return;
+    const host = el as unknown as HTMLElement;
+    if (handle === "a" || handle === "b") {
+      updateEndpoint(host, handle, dx, dy);
+      recomputeLineSvg(el);
+    } else if (handle === "curve") {
+      updateCurve(host, dx, dy);
+      recomputeLineSvg(el);
+    } else if (handle === "rotate") {
+      updateRotate(host, dx);
+      recomputeLineSvg(el);
+    }
+  } catch {}
+}
+
+export function endLineManip(_data: any) {
+  // For future use (e.g., commit, snapping). No-op for now.
+}

--- a/plugins/canvas-component/symphonies/line-advanced/line.manip.start.symphony.ts
+++ b/plugins/canvas-component/symphonies/line-advanced/line.manip.start.symphony.ts
@@ -1,0 +1,4 @@
+import { startLineManip } from "./line.manip.stage-crew";
+
+export const handlers = { startLineManip };
+

--- a/plugins/canvas-component/symphonies/select/select.overlay.line-advanced.stage-crew.ts
+++ b/plugins/canvas-component/symphonies/select/select.overlay.line-advanced.stage-crew.ts
@@ -1,0 +1,322 @@
+import { getCanvasOrThrow } from "./select.overlay.dom.stage-crew";
+import { resolveInteraction } from "../../../../src/interactionManifest";
+import { EventRouter } from "../../../../src/EventRouter";
+import { recomputeLineSvg } from "../augment/line.recompute.stage-crew";
+
+function ensureAdvancedLineCss() {
+  if (typeof document === "undefined") return;
+  const id = "rx-adv-line-overlay-styles";
+  let el = document.getElementById(id) as HTMLStyleElement | null;
+  if (!el) {
+    el = document.createElement("style");
+    el.id = id;
+    document.head.appendChild(el);
+  }
+  const css = `
+  .rx-adv-line-overlay { position:absolute; pointer-events:none; z-index:12; }
+  .rx-adv-line-overlay .handle { position:absolute; width:12px; height:12px; border:2px solid #3b82f6; background:#fff; border-radius:50%; pointer-events:auto; box-sizing:border-box; box-shadow:0 0 0 2px rgba(59,130,246,0.35); }
+  `;
+  if (!(el.textContent || "").includes(".rx-adv-line-overlay")) {
+    el.appendChild(document.createTextNode(css));
+  }
+}
+
+export function ensureAdvancedLineOverlayFor(
+  target: HTMLElement
+): HTMLDivElement {
+  ensureAdvancedLineCss();
+  const canvas = getCanvasOrThrow();
+  let ov = document.getElementById(
+    "rx-adv-line-overlay"
+  ) as HTMLDivElement | null;
+  if (!ov) {
+    ov = document.createElement("div");
+    ov.id = "rx-adv-line-overlay";
+    ov.className = "rx-adv-line-overlay";
+    const a = document.createElement("div");
+    a.className = "handle a";
+    const b = document.createElement("div");
+    b.className = "handle b";
+    ov.appendChild(a);
+    ov.appendChild(b);
+    canvas.appendChild(ov);
+  }
+  // Ensure only endpoint handles are present (cleanup legacy curve/rotate)
+  Array.from(ov.querySelectorAll(".handle.curve, .handle.rotate")).forEach(
+    (n) => n.remove()
+  );
+  if (!ov.querySelector(".handle.a")) {
+    const a = document.createElement("div");
+    a.className = "handle a";
+    ov.appendChild(a);
+  }
+  if (!ov.querySelector(".handle.b")) {
+    const b = document.createElement("div");
+    b.className = "handle b";
+    ov.appendChild(b);
+  }
+
+  // Position overlay to match target's bounding box
+  const r = target.getBoundingClientRect();
+  const cbox = canvas.getBoundingClientRect();
+  ov.style.left = `${Math.round(r.left - cbox.left)}px`;
+  ov.style.top = `${Math.round(r.top - cbox.top)}px`;
+  ov.style.width = `${Math.round(r.width)}px`;
+  ov.style.height = `${Math.round(r.height)}px`;
+
+  try {
+    // Ensure latest geometry, then derive endpoints from actual SVG + viewBox
+    try {
+      const svg = target as unknown as SVGSVGElement;
+      recomputeLineSvg(svg);
+    } catch {}
+
+    const svg = target as unknown as SVGSVGElement;
+    const vb = (svg.getAttribute("viewBox") || "0 0 100 100")
+      .split(/\s+/)
+      .map((v) => parseFloat(v));
+    const [minX, minY, vbW, vbH] = [
+      vb[0] || 0,
+      vb[1] || 0,
+      vb[2] || 100,
+      vb[3] || 100,
+    ];
+
+    const line = svg.querySelector("line.segment") as SVGLineElement | null;
+    const path = svg.querySelector(
+      "path.segment-curve"
+    ) as SVGPathElement | null;
+
+    const toPx = (nx: number, ny: number) => ({
+      x: ((nx - minX) / vbW) * r.width,
+      y: ((ny - minY) / vbH) * r.height,
+    });
+
+    let pA = { x: 0, y: 0 };
+    let pB = { x: r.width, y: r.height };
+
+    if (line && line.style.display !== "none") {
+      const nx1 = parseFloat(line.getAttribute("x1") || "0");
+      const ny1 = parseFloat(line.getAttribute("y1") || "0");
+      const nx2 = parseFloat(line.getAttribute("x2") || String(100));
+      const ny2 = parseFloat(line.getAttribute("y2") || String(0));
+      pA = toPx(nx1, ny1);
+      pB = toPx(nx2, ny2);
+    } else if (path && path.style.display !== "none") {
+      // Use path sampling for accurate endpoints (handles curvature + rotation)
+      const total =
+        typeof path.getTotalLength === "function" ? path.getTotalLength() : 0;
+      if (total > 0 && typeof path.getPointAtLength === "function") {
+        const s = path.getPointAtLength(0);
+        const e = path.getPointAtLength(total);
+        pA = toPx(s.x, s.y);
+        pB = toPx(e.x, e.y);
+      }
+    } else {
+      // Fallback to CSS variables if available
+      const cs =
+        typeof window !== "undefined" ? getComputedStyle(target) : ({} as any);
+      const readVar = (name: string, fallback: string) => {
+        const inline = (target as HTMLElement).style.getPropertyValue(name);
+        const comp =
+          typeof cs.getPropertyValue === "function"
+            ? cs.getPropertyValue(name)
+            : "";
+        const val = inline || comp || fallback;
+        const n = parseFloat(String(val));
+        return Number.isFinite(n) ? n : parseFloat(fallback);
+      };
+      const ax = readVar("--x1", "0");
+      const ay = readVar("--y1", "0");
+      const bx = readVar("--x2", String(r.width));
+      const by = readVar("--y2", String(ay));
+      pA = { x: ax, y: ay };
+      pB = { x: bx, y: by };
+    }
+
+    // Apply rotation if present (rotate around midpoint)
+    const cs =
+      typeof window !== "undefined" ? getComputedStyle(target) : ({} as any);
+    const angleStr =
+      (target as HTMLElement).style.getPropertyValue("--angle") ||
+      (typeof cs.getPropertyValue === "function"
+        ? cs.getPropertyValue("--angle")
+        : "0");
+    const angle = parseFloat(angleStr || "0");
+    if (Number.isFinite(angle) && Math.abs(angle) > 0.0001) {
+      const rad = (angle * Math.PI) / 180;
+      const mx = (pA.x + pB.x) / 2;
+      const my = (pA.y + pB.y) / 2;
+      const rot = (p: { x: number; y: number }) => {
+        const dx = p.x - mx;
+        const dy = p.y - my;
+        const cos = Math.cos(rad);
+        const sin = Math.sin(rad);
+        return { x: mx + dx * cos - dy * sin, y: my + dx * sin + dy * cos };
+      };
+      pA = rot(pA);
+      pB = rot(pB);
+    }
+
+    const a = ov.querySelector(".handle.a") as HTMLDivElement;
+    const b = ov.querySelector(".handle.b") as HTMLDivElement;
+
+    if (a) {
+      a.style.left = `${Math.round(pA.x - 5)}px`;
+      a.style.top = `${Math.round(pA.y - 5)}px`;
+    }
+    if (b) {
+      b.style.left = `${Math.round(pB.x - 5)}px`;
+      b.style.top = `${Math.round(pB.y - 5)}px`;
+    }
+  } catch {}
+  return ov;
+}
+
+export function attachAdvancedLineManipHandlers(
+  ov: HTMLDivElement,
+  conductor?: any
+) {
+  if ((ov as any)._rxAdvLineManipAttached) return;
+  (ov as any)._rxAdvLineManipAttached = true;
+
+  ov.addEventListener("mousedown", (e: MouseEvent) => {
+    const t = e.target as HTMLElement | null;
+    if (!t || !t.classList.contains("handle")) return;
+    e.preventDefault();
+
+    const handle: "a" | "b" = t.classList.contains("a") ? "a" : "b";
+
+    const id = ov.dataset.targetId;
+    if (!id) return;
+    const target = document.getElementById(id) as HTMLElement | null;
+    if (!target) return;
+
+    const start = { x: e.clientX, y: e.clientY };
+
+    let last = { x: start.x, y: start.y };
+    const call = async (phase: "start" | "move" | "end", dx = 0, dy = 0) => {
+      const key =
+        phase === "start"
+          ? "canvas.component.manip.line.start"
+          : phase === "end"
+          ? "canvas.component.manip.line.end"
+          : "canvas.component.manip.line.move";
+      const payload: any = { id, handle, dx, dy, phase };
+      const play = conductor?.play || (window as any).RenderX?.conductor?.play;
+      if (typeof play === "function") {
+        // Prefer EventRouter when topic exists; fall back to direct resolveInteraction
+        try {
+          await EventRouter.publish(
+            key,
+            payload,
+            conductor || (window as any).RenderX?.conductor
+          );
+          return;
+        } catch {
+          try {
+            const r = resolveInteraction(key);
+            await play(r.pluginId, r.sequenceId, payload);
+            return;
+          } catch {}
+        }
+      }
+      // Fallback: directly update CSS vars on target + recompute (endpoints only)
+      if (phase === "move") {
+        const isA = handle === "a";
+        const baseX = parseFloat(
+          target.style.getPropertyValue(isA ? "--x1" : "--x2") || "0"
+        );
+        const baseY = parseFloat(
+          target.style.getPropertyValue(isA ? "--y1" : "--y2") || "0"
+        );
+        const nx = Math.round(baseX + dx);
+        const ny = Math.round(baseY + dy);
+        target.style.setProperty(isA ? "--x1" : "--x2", `${nx}`);
+        target.style.setProperty(isA ? "--y1" : "--y2", `${ny}`);
+        const svg = target as unknown as SVGSVGElement;
+        try {
+          recomputeLineSvg(svg);
+        } catch {}
+        // Reposition both handles based on actual SVG geometry to avoid drift
+        try {
+          const vb = (svg.getAttribute("viewBox") || "0 0 100 100")
+            .split(/\s+/)
+            .map((v) => parseFloat(v));
+          const [minX, minY, vbW, vbH] = [
+            vb[0] || 0,
+            vb[1] || 0,
+            vb[2] || 100,
+            vb[3] || 100,
+          ];
+          const r = (target as HTMLElement).getBoundingClientRect();
+          const toPx = (nx: number, ny: number) => ({
+            x: ((nx - minX) / vbW) * r.width,
+            y: ((ny - minY) / vbH) * r.height,
+          });
+          const line = svg.querySelector(
+            "line.segment"
+          ) as SVGLineElement | null;
+          const path = svg.querySelector(
+            "path.segment-curve"
+          ) as SVGPathElement | null;
+          let pA = { x: 0, y: 0 };
+          let pB = { x: r.width, y: r.height };
+          if (line && line.style.display !== "none") {
+            const nx1 = parseFloat(line.getAttribute("x1") || "0");
+            const ny1 = parseFloat(line.getAttribute("y1") || "0");
+            const nx2 = parseFloat(line.getAttribute("x2") || "100");
+            const ny2 = parseFloat(line.getAttribute("y2") || "0");
+            pA = toPx(nx1, ny1);
+            pB = toPx(nx2, ny2);
+          } else if (path && path.style.display !== "none") {
+            const total =
+              typeof path.getTotalLength === "function"
+                ? path.getTotalLength()
+                : 0;
+            if (total > 0 && typeof path.getPointAtLength === "function") {
+              const s = path.getPointAtLength(0);
+              const e = path.getPointAtLength(total);
+              pA = toPx(s.x, s.y);
+              pB = toPx(e.x, e.y);
+            }
+          }
+          const aEl = ov.querySelector(".handle.a") as HTMLDivElement | null;
+          const bEl = ov.querySelector(".handle.b") as HTMLDivElement | null;
+          if (aEl) {
+            aEl.style.left = `${Math.round(pA.x - 5)}px`;
+            aEl.style.top = `${Math.round(pA.y - 5)}px`;
+          }
+          if (bEl) {
+            bEl.style.left = `${Math.round(pB.x - 5)}px`;
+            bEl.style.top = `${Math.round(pB.y - 5)}px`;
+          }
+        } catch {
+          const endpoint = ov.querySelector(
+            isA ? ".handle.a" : ".handle.b"
+          ) as HTMLDivElement;
+          if (endpoint) {
+            endpoint.style.left = `${nx - 5}px`;
+            endpoint.style.top = `${ny - 5}px`;
+          }
+        }
+      }
+    };
+
+    const onMove = (ev: MouseEvent) => {
+      const dx = ev.clientX - last.x;
+      const dy = ev.clientY - last.y;
+      last = { x: ev.clientX, y: ev.clientY };
+      void call("move", dx, dy);
+    };
+    const onUp = () => {
+      void call("end");
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+
+    void call("start");
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  });
+}

--- a/plugins/canvas-component/symphonies/select/select.stage-crew.ts
+++ b/plugins/canvas-component/symphonies/select/select.stage-crew.ts
@@ -2,6 +2,11 @@ import { ensureOverlay } from "./select.overlay.dom.stage-crew";
 import { attachResizeHandlers } from "./select.overlay.resize.stage-crew";
 import { applyOverlayRectForEl } from "./select.overlay.dom.stage-crew";
 import { useConductor } from "../../../../src/conductor";
+import { isFlagEnabled } from "../../../../src/feature-flags/flags";
+import {
+  ensureAdvancedLineOverlayFor,
+  attachAdvancedLineManipHandlers,
+} from "./select.overlay.line-advanced.stage-crew";
 
 function configureHandlesVisibility(ov: HTMLDivElement, targetEl: HTMLElement) {
   const handlesAttr = targetEl.getAttribute("data-resize-handles");
@@ -27,15 +32,46 @@ export function showSelectionOverlay(data: any, ctx?: any) {
   const el = document.getElementById(String(id)) as HTMLElement | null;
   if (!el) return;
 
-  // Always use the standard selection overlay; behavior is data-driven via attributes
-  const ov = ensureOverlay();
+  // Standard overlay by default; only switch to endpoint overlay when explicitly requested via data-overlay
+  const overlayMode = (el.getAttribute("data-overlay") || "")
+    .trim()
+    .toLowerCase();
+  const wantsEndpointOverlay =
+    overlayMode === "line-advanced" || overlayMode === "line-endpoints";
+  const isSvgLine =
+    el.tagName?.toLowerCase() === "svg" && el.classList.contains("rx-line");
+  const isAdvancedLine =
+    isFlagEnabled("lineAdvanced") &&
+    el.classList.contains("rx-line") &&
+    (wantsEndpointOverlay || isSvgLine);
+
   // Use conductor from context if provided, otherwise get from global context
   const conductor = ctx?.conductor || useConductor();
-  attachResizeHandlers(ov, conductor);
-  ov.dataset.targetId = String(id);
-  configureHandlesVisibility(ov, el);
-  ov.style.display = "block";
-  applyOverlayRectForEl(ov, el);
+
+  if (!isAdvancedLine) {
+    const ov = ensureOverlay();
+    attachResizeHandlers(ov, conductor);
+    ov.dataset.targetId = String(id);
+    configureHandlesVisibility(ov, el);
+    ov.style.display = "block";
+    applyOverlayRectForEl(ov, el);
+  } else {
+    // Hide the standard rectangular overlay for line components
+    const ov = document.getElementById(
+      "rx-selection-overlay"
+    ) as HTMLDivElement | null;
+    if (ov) ov.style.display = "none";
+  }
+
+  // Advanced Line overlay (feature-flag gated): endpoint handles only
+  try {
+    if (isAdvancedLine) {
+      const adv = ensureAdvancedLineOverlayFor(el);
+      adv.dataset.targetId = String(id);
+      attachAdvancedLineManipHandlers(adv, conductor);
+      adv.style.display = "block";
+    }
+  } catch {}
 }
 
 export function hideSelectionOverlay() {


### PR DESCRIPTION
Fixes #99

Summary
- Align advanced line overlay handles with the actual rendered endpoints (SVG-derived)
- Prevent handle drift while dragging by recomputing geometry and repositioning both handles each move
- Add dynamic viewBox autosizing to ensure the line never disappears/clips when resized/rotated beyond bounds
- Add edge-case tests for long/rotated lines and viewBox expansion

Details
- Overlay alignment derives handle positions from the line/path in SVG space and maps via the current viewBox to pixel coordinates; rotation is applied around the segment midpoint
- During drag, the endpoint CSS var is updated, geometry recomputed, then both handles are repositioned using the rendered endpoints (no cumulative error)
- recompute now adjusts viewBox bounds (with padding based on stroke thickness) to include endpoints, rotation extents, and (if in curve mode) the control point

Validation
- Ran the targeted tests:
  - advanced-line.recompute.spec.ts
  - advanced-line.viewbox.autosize.spec.ts
  - advanced-line.overlay.drag.spec.ts
  - advanced-line.resize.scale.spec.ts
- Full test suite passes locally

Notes
- No behavior change when the feature flag is off
- No dependency changes

Please review — happy to iterate on any naming or small refactors the team prefers.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author