### PR TITLE
feat(phase1-issue #102): artifact pipeline, manifest tools package, runtime plugin registration, startup validation, host-sdk extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,82 @@ Check out these supporting projects for more detail on the underlying architectu
 ## Development Workflow
 
 - To add a new plugin:
+### Artifact Mode (External Plugins Repo)
+
+Phase 1 introduces an artifact consumption mode so the thin host can run without plugin source code present.
+
+Artifacts directory expected structure:
+
+```
+interaction-manifest.json
+topics-manifest.json
+layout-manifest.json (optional)
+plugin-manifest.json (inside plugins/)
+json-components/*
+json-sequences/*
+json-interactions/* (optional if already merged)
+json-topics/*
+plugins/plugin-manifest.json
+```
+
+Generate locally:
+```
+node scripts/build-artifacts.js --srcRoot=. --outDir=dist/artifacts
+```
+
+Run host pointing at artifacts:
+```
+set ARTIFACTS_DIR=dist\artifacts
+npm run dev:artifacts
+```
+
+Or (PowerShell inline):
+```
+$env:ARTIFACTS_DIR="dist/artifacts"; npm run dev:artifacts
+```
+
+Script / CLI flags (all accept `--srcRoot` and `--outPublic` where applicable):
+
+| Script | Purpose | Key Flags |
+|--------|---------|----------|
+| `scripts/generate-interaction-manifest.js` | Builds interaction-manifest.json | `--srcRoot`, `--outPublic` |
+| `scripts/generate-topics-manifest.js` | Builds topics-manifest.json | `--srcRoot`, `--outPublic` |
+| `scripts/generate-layout-manifest.js` | Copies layout manifest | `--srcRoot`, `--outPublic` |
+| `scripts/sync-json-components.js` | Copies component JSON | `--srcRoot`, `--outPublic` |
+| `scripts/sync-json-sequences.js` | Copies sequence catalogs | `--srcRoot`, `--outPublic` |
+| `scripts/sync-plugins.js` | Copies plugin manifest(s) | `--srcRoot`, `--outPublic` |
+| `scripts/build-artifacts.js` | Full artifact bundle | `--srcRoot`, `--outDir` |
+| `scripts/copy-artifacts-to-public.js` | Consume existing artifacts | `ARTIFACTS_DIR` env or first arg path |
+
+On startup the host logs a summary like:
+```
+🧪 Startup validation: { routes: 35, topics: 36, plugins: 6 }
+```
+
+Disable this validation (e.g. noisy integration tests) with:
+```
+set RENDERX_DISABLE_STARTUP_VALIDATION=1
+```
+or PowerShell:
+```
+$env:RENDERX_DISABLE_STARTUP_VALIDATION="1"; npm start
+```
+
+### Host SDK Surface (additions)
+
+New helper exports (stable path `@renderx/host-sdk`):
+
+| Export | Purpose |
+|--------|---------|
+| `getPluginManifest()` | Async fetch + cache plugin manifest for discovery tooling |
+| `getCachedPluginManifest()` | Returns last fetched manifest or null |
+| `getAllFlags()` | Snapshot of all feature flags |
+| `getUsageLog()` | In-memory usage log (dev/test diagnostics) |
+| `setFlagOverride(id, enabled)` | Test-only override (do not use in prod code paths) |
+| `clearFlagOverrides()` | Clear all overrides |
+
+These complement existing exports like `useConductor`, `resolveInteraction`, and mapping helpers.
+
 
   - Create a plugin folder under `plugins/`
   - Update the host manifest to include your plugin’s metadata and entry point

--- a/json-plugins/plugin-manifest.json
+++ b/json-plugins/plugin-manifest.json
@@ -30,7 +30,8 @@
         "slot": "library",
         "module": "/plugins/library/index.ts",
         "export": "LibraryPanel"
-      }
+  },
+  "runtime": { "module": "/plugins/library/index.ts", "export": "register" }
     },
     {
       "id": "CanvasPlugin",
@@ -38,7 +39,8 @@
         "slot": "canvas",
         "module": "/plugins/canvas/index.ts",
         "export": "CanvasPage"
-      }
+  },
+  "runtime": { "module": "/plugins/canvas/index.ts", "export": "register" }
     },
     {
       "id": "ControlPanelPlugin",
@@ -46,7 +48,8 @@
         "slot": "controlPanel",
         "module": "/plugins/control-panel/index.ts",
         "export": "ControlPanel"
-      }
+  },
+  "runtime": { "module": "/plugins/control-panel/index.ts", "export": "register" }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "npm run pre:manifests && vite",
     "build": "npm run pre:manifests && vite build",
+  "dev:artifacts": "node scripts/copy-artifacts-to-public.js && vite",
     "preview": "vite preview",
     "pre:manifests": "npm run sync:json-components && node scripts/sync-json-sequences.js && node scripts/generate-interaction-manifest.js && node scripts/generate-topics-manifest.js && node scripts/generate-layout-manifest.js && node scripts/sync-plugins.js",
     "sync:json-components": "node scripts/sync-json-components.js",

--- a/packages/host-sdk/index.ts
+++ b/packages/host-sdk/index.ts
@@ -9,3 +9,7 @@ export {
   computeTagFromJson,
 } from "../../src/component-mapper/mapper";
 export { mapJsonComponentToTemplate } from "../../src/jsonComponent.mapper";
+// Extended flag helpers (read-only + test-only mutators marked clearly)
+export { getAllFlags, getUsageLog, setFlagOverride, clearFlagOverrides } from "../../src/feature-flags/flags";
+// Plugin manifest helpers
+export { getPluginManifest, getCachedPluginManifest } from "./pluginManifest";

--- a/packages/host-sdk/pluginManifest.ts
+++ b/packages/host-sdk/pluginManifest.ts
@@ -1,0 +1,36 @@
+// Lightweight cached accessor for plugin manifest so external plugins can inspect available plugins (non-critical runtime feature)
+export interface HostPluginRuntimeEntry { module: string; export: string }
+export interface HostPluginManifestEntry { id: string; title?: string; description?: string; runtime?: HostPluginRuntimeEntry }
+export interface HostPluginManifest { plugins: HostPluginManifestEntry[] }
+
+let cached: HostPluginManifest | null = null;
+let inflight: Promise<HostPluginManifest> | null = null;
+
+async function load(): Promise<HostPluginManifest> {
+  try {
+    // Try network first
+    const res = await fetch('/plugins/plugin-manifest.json');
+    if (res.ok) {
+      return await res.json();
+    }
+  } catch {}
+  try {
+    // @ts-ignore - raw import provided by bundler
+    const mod = await import(/* @vite-ignore */ '../../public/plugins/plugin-manifest.json?raw');
+    const txt: string = (mod as any)?.default || (mod as any) || '{}';
+    return JSON.parse(txt);
+  } catch {
+    return { plugins: [] };
+  }
+}
+
+export async function getPluginManifest(): Promise<HostPluginManifest> {
+  if (cached) return cached;
+  if (inflight) return inflight;
+  inflight = load().then(m => {
+    cached = m; inflight = null; return m;
+  });
+  return inflight;
+}
+
+export function getCachedPluginManifest(): HostPluginManifest | null { return cached; }

--- a/packages/manifest-tools/package.json
+++ b/packages/manifest-tools/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@renderx/manifest-tools",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  }
+}

--- a/packages/manifest-tools/src/index.js
+++ b/packages/manifest-tools/src/index.js
@@ -1,0 +1,35 @@
+// Runtime JS version of manifest tools for Node scripts
+
+export function buildInteractionManifest(catalogs, componentOverrideMaps) {
+  const routes = {};
+  for (const cat of catalogs || []) {
+    const r = (cat && cat.routes) || {};
+    for (const k of Object.keys(r)) routes[k] = r[k];
+  }
+  for (const o of componentOverrideMaps || []) {
+    for (const k of Object.keys(o || {})) routes[k] = o[k];
+  }
+  return { version: '1.0.0', routes };
+}
+
+export function buildTopicsManifest(catalogs) {
+  const topics = {};
+  for (const cat of catalogs || []) {
+    const t = (cat && cat.topics) || {};
+    for (const key of Object.keys(t)) {
+      const def = t[key] || {};
+      const routes = [];
+      if (def.route) routes.push(def.route);
+      if (Array.isArray(def.routes)) routes.push(...def.routes);
+      topics[key] = {
+        routes,
+        payloadSchema: def.payloadSchema || null,
+        visibility: def.visibility || 'public',
+        correlationKeys: Array.isArray(def.correlationKeys) ? def.correlationKeys : [],
+        perf: def.perf || {},
+        notes: def.notes || ''
+      };
+    }
+  }
+  return { version: '1.0.0', topics };
+}

--- a/packages/manifest-tools/src/index.ts
+++ b/packages/manifest-tools/src/index.ts
@@ -1,0 +1,54 @@
+// Shared pure builders & types for manifests (Phase 1 extraction)
+
+export interface InteractionRoute { pluginId: string; sequenceId: string }
+export interface InteractionManifest { version: string; routes: Record<string, InteractionRoute> }
+
+export function buildInteractionManifest(
+  catalogs: Array<any>,
+  componentOverrideMaps: Array<Record<string, InteractionRoute>>
+): InteractionManifest {
+  const routes: Record<string, InteractionRoute> = {};
+  for (const cat of catalogs || []) {
+    const r = cat?.routes || {};
+    for (const [k, v] of Object.entries(r)) routes[k] = v as InteractionRoute;
+  }
+  for (const o of componentOverrideMaps || []) {
+    for (const [k, v] of Object.entries(o || {})) routes[k] = v as InteractionRoute;
+  }
+  return { version: '1.0.0', routes };
+}
+
+export interface TopicRoute { pluginId: string; sequenceId: string }
+export interface TopicDef {
+  routes: TopicRoute[];
+  payloadSchema?: any;
+  visibility?: 'public' | 'internal';
+  correlationKeys?: string[];
+  perf?: { throttleMs?: number; debounceMs?: number; dedupeWindowMs?: number };
+  notes?: string;
+}
+export interface TopicsManifest { version: string; topics: Record<string, TopicDef> }
+
+export function buildTopicsManifest(catalogs: Array<any>): TopicsManifest {
+  const topics: Record<string, TopicDef> = {};
+  for (const cat of catalogs || []) {
+    const t = cat?.topics || {};
+    for (const [key, defAny] of Object.entries<any>(t)) {
+      const def = defAny || {};
+      const routes: TopicRoute[] = [];
+      if (def.route) routes.push(def.route);
+      if (Array.isArray(def.routes)) routes.push(...def.routes);
+      topics[key] = {
+        routes,
+        payloadSchema: def.payloadSchema || null,
+        visibility: def.visibility || 'public',
+        correlationKeys: Array.isArray(def.correlationKeys) ? def.correlationKeys : [],
+        perf: def.perf || {},
+        notes: def.notes || ''
+      };
+    }
+  }
+  return { version: '1.0.0', topics };
+}
+
+export interface LayoutManifest { layout: any; slots: any[] }

--- a/scripts/build-artifacts.js
+++ b/scripts/build-artifacts.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+/**
+ * Phase 1 helper: build consolidated artifact directory from local json-* sources.
+ * Usage: node scripts/build-artifacts.js --srcRoot=. --outDir=dist/artifacts
+ */
+
+import { mkdir, cp, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { buildInteractionManifest, buildTopicsManifest } from '../packages/manifest-tools/src/index.js';
+import { promises as fs } from 'fs';
+
+const __dirname = new URL('.', import.meta.url).pathname;
+const rootDir = join(__dirname, '..');
+const args = process.argv.slice(2);
+function getArg(name, def) {
+  const i = args.findIndex(a => a === name || a.startsWith(name + '='));
+  if (i === -1) return def;
+  const eq = args[i].indexOf('=');
+  if (eq > -1) return args[i].slice(eq + 1);
+  const nxt = args[i + 1];
+  if (nxt && !nxt.startsWith('--')) return nxt;
+  return def;
+}
+const srcRoot = getArg('--srcRoot', rootDir);
+const outDir = getArg('--outDir', join(rootDir, 'dist', 'artifacts'));
+
+async function readJsonSafe(p) { try { return JSON.parse(await fs.readFile(p,'utf-8')); } catch { return null; } }
+
+async function collect(dir) {
+  try { const ents = await fs.readdir(dir); return ents.filter(f=>f.endsWith('.json')).map(f=>readJsonSafe(join(dir,f))); } catch { return []; }
+}
+
+async function build() {
+  console.log('🧱 Building artifacts from', srcRoot, '→', outDir);
+  await mkdir(outDir, { recursive: true });
+  const paths = {
+    components: join(srcRoot, 'json-components'),
+    sequences: join(srcRoot, 'json-sequences'),
+    interactions: join(srcRoot, 'json-interactions'),
+    topics: join(srcRoot, 'json-topics'),
+    plugins: join(srcRoot, 'json-plugins'),
+    layout: join(srcRoot, 'json-layout'),
+  };
+
+  // Copy trees
+  async function copyTree(rel) {
+    const from = paths[rel];
+    try {
+      await cp(from, join(outDir, rel), { recursive: true });
+      console.log('✅ Copied', rel);
+    } catch {}
+  }
+  await Promise.all(['components','sequences','interactions','topics','plugins','layout'].map(copyTree));
+
+  // Rebuild synthesized manifests for portability
+  // Interaction
+  const interactionCats = await Promise.all(await collect(paths.interactions));
+  const componentFiles = await Promise.all(await collect(paths.components));
+  function extractOverrides(json) {
+    return json?.integration?.routeOverrides || json?.routeOverrides || json?.integration?.interactions?.routeOverrides || {}; }
+  const overrides = componentFiles.map(extractOverrides);
+  const interactionManifest = buildInteractionManifest(interactionCats.filter(Boolean), overrides);
+  await writeFile(join(outDir, 'interaction-manifest.json'), JSON.stringify(interactionManifest,null,2));
+
+  // Topics
+  const topicCats = await Promise.all(await collect(paths.topics));
+  const topicsManifest = buildTopicsManifest(topicCats.filter(Boolean));
+  await writeFile(join(outDir, 'topics-manifest.json'), JSON.stringify(topicsManifest,null,2));
+
+  // Layout (copy single file if present)
+  const layout = await readJsonSafe(join(paths.layout,'layout.json'));
+  if (layout) await writeFile(join(outDir,'layout-manifest.json'), JSON.stringify(layout,null,2));
+
+  // Summary file
+  const summary = {
+    version: '1.0.0',
+    counts: {
+      interactionRoutes: Object.keys(interactionManifest.routes).length,
+      topics: Object.keys(topicsManifest.topics).length,
+      components: componentFiles.filter(Boolean).length,
+    }
+  };
+  await writeFile(join(outDir,'manifest-set.json'), JSON.stringify(summary,null,2));
+  console.log('✨ Artifact build complete');
+}
+
+build().catch(e=>{ console.error('Artifact build failed', e); process.exit(1); });

--- a/scripts/copy-artifacts-to-public.js
+++ b/scripts/copy-artifacts-to-public.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// Copies pre-built artifact set into public/ (used in dev:artifacts mode)
+import { cp, mkdir } from 'fs/promises';
+import { join } from 'path';
+
+const artifactsDir = process.env.ARTIFACTS_DIR || process.argv.slice(2)[0];
+if (!artifactsDir) {
+  console.error('Provide ARTIFACTS_DIR env or first arg path to artifacts directory');
+  process.exit(1);
+}
+const target = join(process.cwd(), 'public');
+await mkdir(target, { recursive: true });
+await cp(artifactsDir, target, { recursive: true });
+console.log('✅ Copied artifacts from', artifactsDir, 'to public/');

--- a/scripts/sync-json-components.js
+++ b/scripts/sync-json-components.js
@@ -13,8 +13,21 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
 
-const sourceDir = join(rootDir, 'json-components');
-const targetDir = join(rootDir, 'public', 'json-components');
+const args = process.argv.slice(2);
+function getArg(name, def) {
+  const i = args.findIndex(a => a === name || a.startsWith(name + '='));
+  if (i === -1) return def;
+  const eq = args[i].indexOf('=');
+  if (eq > -1) return args[i].slice(eq + 1);
+  const nxt = args[i + 1];
+  if (nxt && !nxt.startsWith('--')) return nxt;
+  return def;
+}
+const srcRoot = getArg('--srcRoot', rootDir);
+const outPublic = getArg('--outPublic', join(rootDir, 'public'));
+
+const sourceDir = join(srcRoot, 'json-components');
+const targetDir = join(outPublic, 'json-components');
 
 async function ensureDir(dir) {
   try {

--- a/scripts/sync-json-sequences.js
+++ b/scripts/sync-json-sequences.js
@@ -5,22 +5,28 @@
  * Ensures the dev server serves the latest sequence catalogs in the browser.
  */
 
-import {
-  readdir,
-  readFile,
-  writeFile,
-  mkdir,
-  stat as _stat,
-} from "fs/promises";
+import { readdir, readFile, writeFile, mkdir } from "fs/promises";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, "..");
+const args = process.argv.slice(2);
+function getArg(name, def) {
+  const i = args.findIndex(a => a === name || a.startsWith(name + '='));
+  if (i === -1) return def;
+  const eq = args[i].indexOf('=');
+  if (eq > -1) return args[i].slice(eq + 1);
+  const nxt = args[i + 1];
+  if (nxt && !nxt.startsWith('--')) return nxt;
+  return def;
+}
+const srcRoot = getArg('--srcRoot', rootDir);
+const outPublic = getArg('--outPublic', join(rootDir, 'public'));
 
-const sourceDir = join(rootDir, "json-sequences");
-const targetDir = join(rootDir, "public", "json-sequences");
+const sourceDir = join(srcRoot, "json-sequences");
+const targetDir = join(outPublic, "json-sequences");
 
 async function ensureDir(dir) {
   try {

--- a/scripts/sync-plugins.js
+++ b/scripts/sync-plugins.js
@@ -11,9 +11,21 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
+const args = process.argv.slice(2);
+function getArg(name, def) {
+  const i = args.findIndex(a => a === name || a.startsWith(name + '='));
+  if (i === -1) return def;
+  const eq = args[i].indexOf('=');
+  if (eq > -1) return args[i].slice(eq + 1);
+  const nxt = args[i + 1];
+  if (nxt && !nxt.startsWith('--')) return nxt;
+  return def;
+}
+const srcRoot = getArg('--srcRoot', rootDir);
+const outPublic = getArg('--outPublic', join(rootDir, 'public'));
 
-const sourceDir = join(rootDir, 'json-plugins');
-const targetDir = join(rootDir, 'public', 'plugins');
+const sourceDir = join(srcRoot, 'json-plugins');
+const targetDir = join(outPublic, 'plugins');
 
 async function ensureDir(dir) {
   try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import { initConductor, registerAllSequences } from "./conductor";
-import { initInteractionManifest } from "./interactionManifest";
-import { initTopicsManifest } from "./topicsManifest";
+import { initInteractionManifest, getInteractionManifestStats } from "./interactionManifest";
+import { initTopicsManifest, getTopicsManifestStats } from "./topicsManifest";
+import { getPluginManifestStats } from "./startupValidation";
 import { EventRouter } from "./EventRouter";
 import "./global.css";
+// minimal ambient typing for optional env flag without pulling full @types/node
+declare const process: { env?: Record<string, string | undefined> } | undefined;
 
 (async () => {
   const conductor = await initConductor();
@@ -15,6 +18,21 @@ import "./global.css";
     initTopicsManifest(),
     EventRouter.init(),
   ]);
+
+  if (!(typeof process !== 'undefined' && process.env?.RENDERX_DISABLE_STARTUP_VALIDATION === '1')) {
+    try {
+      const interactionStats = getInteractionManifestStats();
+      const topicsStats = getTopicsManifestStats();
+      const pluginStats = await getPluginManifestStats();
+      console.log("🧪 Startup validation:", {
+        routes: interactionStats.routeCount,
+        topics: topicsStats.topicCount,
+        plugins: pluginStats.pluginCount,
+      });
+    } catch (e) {
+      console.warn("Startup validation failed", e);
+    }
+  }
 
   const rootEl = document.getElementById("root");
   if (!rootEl) {

--- a/src/startupValidation.ts
+++ b/src/startupValidation.ts
@@ -1,0 +1,23 @@
+// Lightweight manifest presence & counts for host startup logging
+
+export async function getPluginManifestStats() {
+  try {
+    const isBrowser = typeof window !== 'undefined' && typeof (globalThis as any).fetch === 'function';
+    let json: any = null;
+    if (isBrowser) {
+      const res = await fetch('/plugins/plugin-manifest.json');
+      if (res.ok) json = await res.json();
+    }
+    if (!json) {
+      // @ts-ignore
+      const mod = await import(/* @vite-ignore */ '../public/plugins/plugin-manifest.json?raw');
+      const txt: string = (mod as any)?.default || (mod as any) || '{}';
+      json = JSON.parse(txt);
+    }
+    const plugins = Array.isArray(json.plugins) ? json.plugins : [];
+    return { pluginCount: plugins.length };
+  } catch (e) {
+    console.warn('[startupValidation] Failed reading plugin-manifest.json', e);
+    return { pluginCount: 0 };
+  }
+}

--- a/src/topicsManifest.ts
+++ b/src/topicsManifest.ts
@@ -1,76 +1,30 @@
-export interface TopicRoute {
-  pluginId: string;
-  sequenceId: string;
-}
-
+export interface TopicRoute { pluginId: string; sequenceId: string }
 export interface TopicDef {
   routes: TopicRoute[];
   payloadSchema?: any;
-  visibility?: "public" | "internal";
+  visibility?: 'public' | 'internal';
   correlationKeys?: string[];
   perf?: { throttleMs?: number; debounceMs?: number; dedupeWindowMs?: number };
   notes?: string;
 }
 
-let topics: Record<string, TopicDef> = {};
-let loaded = false;
+// Static JSON import ensures synchronous availability for tests and early runtime callers
+// @ts-ignore - JSON assertion supported by bundler / TS
+import topicsManifestJson from '../topics-manifest.json' assert { type: 'json' };
 
-// Try to eagerly preload in Vite/Vitest (sync)
-try {
-  // @ts-ignore - Vite-specific API
-  const files = (import.meta as any).glob("../topics-manifest.json", {
-    eager: true,
-    query: "?raw",
-    import: "default",
-  });
-  const text: string | undefined = files?.["../topics-manifest.json"];
-  if (typeof text === "string") {
-    const json = JSON.parse(text || "{}");
-    topics = json?.topics || {};
-    loaded = true;
-  }
-} catch {}
+let topics: Record<string, TopicDef> = (topicsManifestJson as any)?.topics || {};
+let loaded = true;
 
-async function loadManifest(): Promise<void> {
-  try {
-    const isBrowser =
-      typeof globalThis !== "undefined" &&
-      typeof (globalThis as any).fetch === "function";
-    if (isBrowser) {
-      const res = await fetch("/topics-manifest.json");
-      if (res.ok) {
-        const json = await res.json();
-        topics = json?.topics || {};
-        loaded = true;
-        return;
-      }
-    }
-    const mod = await import(/* @vite-ignore */ "../topics-manifest.json?raw");
-    const text: string = (mod as any)?.default || (mod as any) || "{}";
-    const json = JSON.parse(text);
-    topics = json?.topics || {};
-    loaded = true;
-  } catch {
-    topics = {};
-    loaded = true;
-  }
-}
-
-export async function initTopicsManifest(): Promise<void> {
-  if (!loaded) await loadManifest();
-}
+// No-op to keep previous API surface
+export async function initTopicsManifest(): Promise<void> { /* already loaded */ }
 
 export function getTopicDef(key: string): TopicDef | undefined {
-  if (!loaded) {
-    // fire-and-forget lazy load; tests should call init explicitly
-    // @ts-ignore
-    loadManifest();
-  }
   return topics[key];
 }
 
-// test-only: allow injection of topics for unit tests without I/O
+// test-only: allow injection of topics (maintain API)
 export function __setTopics(map: Record<string, TopicDef>) {
   topics = map || {};
-  loaded = true;
 }
+
+export function getTopicsManifestStats() { return { loaded, topicCount: Object.keys(topics).length }; }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "baseUrl": ".",
     "paths": {}
   },
-  "include": ["plugins", "__tests__", "src", "data"]
+  "include": ["plugins", "__tests__", "src", "data", "packages"]
 }


### PR DESCRIPTION
## Summary
Implements Phase 1 of the repo split enablement:
- Adds manifest-tools workspace package (shared pure builders for interaction + topics manifests)
- Parameterizes manifest + sync scripts with --srcRoot / --outPublic / --outDir
- Adds artifact build (scripts/build-artifacts.js) and dev consumption flow (dev:artifacts + copy-artifacts script)
- Converts plugin runtime registration to manifest-driven (plugin-manifest runtime.module/export)
- Removes eager manifest glob preloads to eliminate Vite dual import warnings
- Adds startup validation log (counts routes/topics/plugins) with env gate RENDERX_DISABLE_STARTUP_VALIDATION=1
- Extends host SDK (plugin manifest access + flag helpers)
- Adds safer fallback loading for manifests (test stability)
- Updates README with Artifact Mode, env var, and new SDK exports

## Key Files Added
- packages/manifest-tools/*
- build-artifacts.js
- copy-artifacts-to-public.js
- pluginManifest.ts
- startupValidation.ts

## Breaking Changes
- Plugins should rely on runtime registration via plugin-manifest (ensure runtime entries present)
- Topics manifest now synchronously imported (ensures test reliability)

## Verification
- All tests: 330 passed / 0 failed (Vitest)
- Manual build succeeded locally
- dev:artifacts path documented

## Follow-ups (Phase 2+)
- d.ts packaging & public API pruning for host-sdk
- Artifact integrity hashing + watch pipeline
- ESLint rule path configurability for external plugin repo
- Repo extraction scripts & publishing workflow
