### PR TITLE
docs(#115): ADR-0026 — Library decoupling and externalization plan (host-owned inventory via SDK)

### DIFF
--- a/docs/adr/ADR-0026 — Library Decoupling — Host-owned Inventory and Externalized Library Plugin.md
+++ b/docs/adr/ADR-0026 — Library Decoupling — Host-owned Inventory and Externalized Library Plugin.md
@@ -1,0 +1,131 @@
+# ADR-0026 — Library Decoupling: Host-owned Inventory and Externalized Library Plugin
+
+Status: Proposed
+Date: 2025-09-10
+Relates to: #115
+
+## Context
+- The Header plugin has been externalized as an npm package and is loaded via package specifier in the plugin manifest.
+- The Library plugin remains in-repo and is coupled to:
+  - repo-local component JSON (/json-components) access paths, and
+  - a cross-plugin import of Control Panel’s `cssRegistry` store.
+- For long-term scalability, orchestration, and runtime extensibility, the host should own the unified component inventory and expose it via a stable SDK.
+- Plugins should interact only through the Host SDK boundary and avoid importing host internals or other plugins’ internals.
+
+## Decision
+- Host-owned inventory, exposed via @renderx-plugins/host-sdk with minimal, composable APIs:
+  - `listComponents(): Promise<ComponentSummary[]>`
+  - `getComponentById(id: string): Promise<ComponentDetail | undefined>`
+  - `onInventoryChanged(cb: (event) => void): () => void` (unsubscribe)
+  - (optional) `registerComponents(components: ComponentDetail[])`
+- Introduce an SDK facade for CSS registry management used by plugins:
+  - `cssRegistry.hasClass(name)`, `cssRegistry.createClass(name, content)`, `cssRegistry.updateClass(name, content)`
+- Externalize the Library plugin as `@renderx-plugins/library` and load it via package specifier for both UI and runtime registration.
+- Sequences continue to be registered into the Conductor during host startup; plugins provide a `register(conductor)` runtime export.
+- Enforce boundaries with a new ESLint rule forbidding cross-plugin imports (complements existing no-host-internals-in-plugins).
+
+## Architecture (Mermaid)
+```mermaid
+flowchart LR
+  subgraph Host[Host App (Thin Shell)]
+    PanelSlot[PanelSlot]
+    SDK[Host SDK (Facade)]
+    Conductor[Conductor]
+    Inv[Inventory Aggregator]
+  end
+
+  subgraph Plugins
+    Lib[@renderx-plugins/library]
+    Head[@renderx-plugins/header]
+    CP[Control Panel]
+  end
+
+  PanelSlot -- manifest: UI module --> Lib
+  PanelSlot -- manifest: UI module --> Head
+
+  Lib -- listComponents()/getComponent() --> SDK
+  SDK --> Inv
+
+  Lib -- cssRegistry.*() --> SDK
+  SDK -- facade --> CP
+
+  Host -- manifest: runtime register --> Conductor
+  Conductor -. calls .-> Lib
+  Conductor -. calls .-> Head
+
+  CP -. contributes (optional) .-> Inv
+  Lib -. contributes (optional) .-> Inv
+```
+
+## Future Structures (ASCII)
+```
+renderx-plugins-demo/                    # host repo
+├─ docs/
+│  └─ adr/
+├─ json-plugins/
+│  └─ plugin-manifest.json               # uses package specifiers for Library/Header
+├─ src/
+│  ├─ conductor.ts                       # runtimePackageLoaders includes @renderx-plugins/library
+│  └─ ...
+└─ packages/
+   └─ host-sdk/
+      └─ src/
+         ├─ inventory.ts                 # list/get/observe inventory
+         └─ cssRegistry.ts               # css class registry facade
+
+# External plugin repo
+renderx-plugin-library/
+├─ package.json (exports ./dist/index.js)
+├─ src/
+│  ├─ index.ts                           # export LibraryPanel, export async function register(conductor)
+│  ├─ ui/LibraryPanel.tsx
+│  └─ symphonies/load.symphony.ts        # uses SDK inventory + cssRegistry
+└─ dist/
+```
+
+## Consequences
+- Clear separation of concerns: host orchestrates and exposes inventory; plugins consume via SDK.
+- Library becomes portable and distributable; the host manifest uses package specifiers.
+- Boundary violations (e.g., cross-plugin imports) are prevented by lint policy.
+- Additional host responsibility: aggregate inventories (built-in + contributions), keep APIs stable under semver.
+
+## Implementation Plan (Phased, TDD-first)
+1) Policy & Tests
+- Add ESLint rule `no-cross-plugin-imports` and unit tests.
+- Add a manifest validation test ensuring Library uses a package specifier when enabled.
+- Add import-path tests ensuring Library references SDK for inventory and cssRegistry.
+
+2) SDK + Host Aggregator
+- Add inventory API to the Host SDK.
+- Add cssRegistry facade to the Host SDK.
+- Implement host-side aggregator (dev/test: read /json-components; support runtime contributions).
+
+3) Library Refactor
+- Replace `../../control-panel/state/css-registry.store` import with SDK `cssRegistry`.
+- Replace repo-path JSON access with SDK inventory calls (browser + test paths).
+
+4) Externalization & Manifest
+- Create/publish `@renderx-plugins/library`.
+- Update `json-plugins/plugin-manifest.json` to use package specifier for Library UI/runtime.
+- Add `@renderx-plugins/library` to runtimePackageLoaders and Vite optimizeDeps.
+
+5) Stabilization
+- Unit tests and E2E: Library panel render + basic interaction.
+- Optional short transition window (feature-flagged) before removing in-repo Library.
+
+## Alternatives Considered
+- Library owning the inventory: rejected for orchestration and duplication concerns.
+- Keeping JSON catalogs as the sole source for Library: acceptable during transition, but programmatic registration via `register(conductor)` is preferred long term.
+- Moving cssRegistry into a separate shared package instead of SDK: possible, but SDK facade provides a single, stable boundary and aligns with ADR-0023.
+
+## Risks & Mitigations
+- Runtime loading issues for external package → Prebundle config and runtimePackageLoader entries; CI E2E smoke.
+- API creep in inventory → Start minimal (list/get/observe); iterate under semver.
+- Transitional complexity → Feature flag + dual-mode support temporarily.
+
+## References
+- Issue #115 — Decouple Library Plugin: Host-owned Inventory via SDK, Externalize @renderx-plugins/library, and Enforce Boundaries
+- ADR-0023 — Host SDK and Plugin Decoupling
+- docs/design-reviews/library-decoupling-review.md
+- docs/host-sdk/USING_HOST_SDK.md
+


### PR DESCRIPTION
This PR adds ADR-0026, documenting the plan to decouple the Library plugin, move to host-owned component inventory exposed via the Host SDK, and enforce plugin boundaries.

- ADR: docs/adr/ADR-0026 — Library Decoupling — Host-owned Inventory and Externalized Library Plugin.md
- References: #115

Summary:
- Host owns unified component inventory; SDK exposes list/get/observe API
- SDK facade for cssRegistry (has/create/update)
- Library to be externalized and loaded via package specifier (@renderx-plugins/library)
- Sequences registered via Conductor at host startup
- New ESLint rule to forbid cross-plugin imports (complements existing boundary rule)

Includes Mermaid diagram and ASCII structure sketches. This is documentation only; functional changes will be proposed in follow-up PRs (tests-first).


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author