### PR TITLE
feat(#122): externalize library-component runtime — manifest entry, conductor mapping, tests

### DIFF
--- a/__tests__/library-component/runtime.register.spec.ts
+++ b/__tests__/library-component/runtime.register.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerAllSequences } from '../../src/conductor';
+
+function createFakeConductor() {
+  const mounted: any[] = [];
+  return {
+    mounted,
+    logger: { warn: vi.fn(), info: vi.fn() },
+    async mount(seq: any, _handlers: any, pluginId: string) {
+      mounted.push({ seq, pluginId });
+    },
+    getMountedPluginIds() {
+      return Array.from(new Set(mounted.map(m => m.pluginId)));
+    },
+  };
+}
+
+describe('@renderx-plugins/library-component runtime registration', () => {
+  it('registerAllSequences() loads runtime and mounts library-component sequences (even if JSON catalogs also mount)', async () => {
+    const c = createFakeConductor();
+    await registerAllSequences(c as any);
+
+    const ids = c.mounted.map((m: any) => m.seq?.id);
+    expect(ids).toContain('library-component-drag-symphony');
+    expect(ids).toContain('library-component-drop-symphony');
+    expect(ids).toContain('library-component-container-drop-symphony');
+
+    const pluginIds = c.getMountedPluginIds();
+    expect(pluginIds).toContain('LibraryComponentPlugin');
+    expect(pluginIds).toContain('LibraryComponentDropPlugin');
+  }, 60000);
+});
+

--- a/__tests__/manifest/library-component.manifest.spec.ts
+++ b/__tests__/manifest/library-component.manifest.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import manifest from '../../json-plugins/plugin-manifest.json';
+
+/**
+ * TDD: Ensure host manifest includes a runtime-only entry for the externalized
+ * library-component package using a bare package specifier and register export.
+ */
+describe('Library-Component runtime manifest entry', () => {
+  it('lists @renderx-plugins/library-component with export register', () => {
+    const plugins = (manifest as any)?.plugins || [];
+    const entries = plugins.filter((p: any) => p?.runtime?.module === '@renderx-plugins/library-component');
+    expect(entries.length).toBeGreaterThan(0);
+    const anyEntry = entries[0];
+    expect(anyEntry.runtime?.export).toBe('register');
+  });
+});
+

--- a/json-plugins/plugin-manifest.json
+++ b/json-plugins/plugin-manifest.json
@@ -50,6 +50,10 @@
         "export": "ControlPanel"
   },
   "runtime": { "module": "/plugins/control-panel/index.ts", "export": "register" }
+    },
+    {
+      "id": "LibraryComponentPlugin",
+      "runtime": { "module": "@renderx-plugins/library-component", "export": "register" }
     }
   ]
 }

--- a/packages/renderx-plugin-library-component/README.md
+++ b/packages/renderx-plugin-library-component/README.md
@@ -1,0 +1,12 @@
+# @renderx-plugins/library-component (temporary in-repo)
+
+This is a temporary runtime-only package that registers Library-Component drag/drop sequences.
+It exists in-repo to support decoupling and will be extracted to its own repository and
+published to npm under `@renderx-plugins/library-component`.
+
+- Entry: `src/index.ts`
+- Export: `register(conductor)`
+- Sequences: drag, drop, container-drop
+
+Once externalized, this package will depend only on the Host SDK and its own handlers.
+

--- a/packages/renderx-plugin-library-component/package.json
+++ b/packages/renderx-plugin-library-component/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@renderx-plugins/library-component",
+  "version": "0.0.0-dev",
+  "private": true,
+  "description": "Temporary in-repo runtime package for Library-Component; to be externalized and published.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": false,
+  "license": "UNLICENSED"
+}
+

--- a/packages/renderx-plugin-library-component/src/index.ts
+++ b/packages/renderx-plugin-library-component/src/index.ts
@@ -1,0 +1,60 @@
+// Temporary in-repo runtime package for Library-Component until externalized
+// Registers drag.start, drop (component), and drop (container) sequences using existing handlers.
+
+import { handlers as dragHandlers } from '../../../../plugins/library-component/symphonies/drag.symphony';
+import { handlers as dropHandlers } from '../../../../plugins/library-component/symphonies/drop.symphony';
+import { handlers as containerDropHandlers } from '../../../../plugins/library-component/symphonies/drop.container.symphony';
+
+export async function register(conductor: any) {
+  if (!conductor?.mount) return;
+
+  const dragSeq = {
+    pluginId: 'LibraryComponentPlugin',
+    id: 'library-component-drag-symphony',
+    name: 'Library Component Drag',
+    movements: [
+      {
+        id: 'drag',
+        name: 'Drag',
+        beats: [
+          { beat: 1, event: 'library:component:drag:start', handler: 'onDragStart', kind: 'pure', dynamics: 'mf', timing: 'immediate' },
+        ],
+      },
+    ],
+  } as any;
+
+  const dropSeq = {
+    pluginId: 'LibraryComponentDropPlugin',
+    id: 'library-component-drop-symphony',
+    name: 'Library Component Drop',
+    movements: [
+      {
+        id: 'drop',
+        name: 'Drop',
+        beats: [
+          { beat: 1, event: 'library:component:drop', handler: 'publishCreateRequested', kind: 'pure', dynamics: 'mf', timing: 'immediate' },
+        ],
+      },
+    ],
+  } as any;
+
+  const containerDropSeq = {
+    pluginId: 'LibraryComponentDropPlugin',
+    id: 'library-component-container-drop-symphony',
+    name: 'Library Component Container Drop',
+    movements: [
+      {
+        id: 'drop',
+        name: 'Drop',
+        beats: [
+          { beat: 1, event: 'library:container:drop', handler: 'publishCreateRequested', kind: 'pure', dynamics: 'mf', timing: 'immediate' },
+        ],
+      },
+    ],
+  } as any;
+
+  await conductor.mount(dragSeq, dragHandlers, dragSeq.pluginId);
+  await conductor.mount(dropSeq, dropHandlers, dropSeq.pluginId);
+  await conductor.mount(containerDropSeq, containerDropHandlers, containerDropSeq.pluginId);
+}
+

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -25,6 +25,8 @@ function resolveModuleSpecifier(spec: string): string {
 const runtimePackageLoaders: Record<string, () => Promise<any>> = {
   '@renderx-plugins/header': () => import('@renderx-plugins/header'),
   '@renderx-plugins/library': () => import('@renderx-plugins/library'),
+  // Temporary in-repo mapping for runtime-only library-component until externalized
+  '@renderx-plugins/library-component': () => import('/packages/renderx-plugin-library-component/src/index.ts'),
 };
 
 


### PR DESCRIPTION
Summary
- Add runtime externalization path for Library-Component via bare package specifier `@renderx-plugins/library-component`
- Temporary in-repo package provides register(conductor) that mounts drag, drop, and container drop sequences
- Conductor loads runtime through static mapping to in-repo package pending external publish

Changes
- json-plugins/plugin-manifest.json: add LibraryComponentPlugin runtime { module: "@renderx-plugins/library-component", export: "register" }
- src/conductor.ts: add runtimePackageLoaders mapping for '@renderx-plugins/library-component' → in-repo package path
- packages/renderx-plugin-library-component/: new temp runtime package (src/index.ts, package.json, README)
- __tests__/manifest/library-component.manifest.spec.ts: asserts manifest includes runtime entry
- __tests__/library-component/runtime.register.spec.ts: validates registerAllSequences() mounts the three sequences with expected pluginIds

Docs
- ADR-0027 — Library-Component Externalization — Drag and Drop Runtime via Host SDK (docs/adr/ADR-0027 — Library-Component Externalization — Drag and Drop Runtime via Host SDK.md) tracks the decision and links to #122

Validation
- Lint: pass
- Tests: full suite pass
- Build: pass (vite build)

Notes
- The package is marked private and lives in-repo temporarily; Phase 2 will extract to a standalone repo and publish to npm.
- We deliberately excluded json-plugins/.generated/* from this commit.

Relates to: #122

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author