### PR TITLE
test(#130): guardrail for externalized plugins (runtime register + handlers)

### DIFF
--- a/__tests__/manifest/valid-external-handlers.spec.ts
+++ b/__tests__/manifest/valid-external-handlers.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { normalizeHandlersImportSpec, isBareSpecifier } from '../../src/handlersPath';
+
+/**
+ * Guardrail tests for externalized plugins (issue #130)
+ * - Verify manifest runtime exports exist and are callable for bare package specifiers
+ * - Verify JSON-mounted sequences that use bare package handlersPath export a handlers object
+ *   and that all referenced beat.handler names exist in that object
+ */
+
+describe('Externalized plugins: runtime register and handlers exports', () => {
+  const repoRoot = path.resolve(__dirname, '..', '..');
+  const publicDir = path.join(repoRoot, 'public');
+
+  it('manifest runtime exports are callable for bare package plugins', async () => {
+    const manifestPath = path.join(publicDir, 'plugins', 'plugin-manifest.json');
+    expect(fs.existsSync(manifestPath)).toBe(true);
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as any;
+    const plugins = Array.isArray(manifest?.plugins) ? manifest.plugins : [];
+
+    // Only check bare package specifiers (externalized plugins)
+    const targets = plugins.filter((p: any) => p?.runtime?.module && isBareSpecifier(p.runtime.module));
+    expect(targets.length).toBeGreaterThan(0);
+
+    for (const p of targets) {
+      const modSpec = p.runtime.module as string;
+      const exportName = p.runtime.export as string;
+      // For Node/Vitest, pass isBrowser=false; bare spec remains unchanged
+      const spec = normalizeHandlersImportSpec(false, modSpec);
+      const mod: any = await import(spec);
+      const fn = mod?.[exportName];
+      expect(typeof fn, `Plugin '${p.id}' missing runtime export '${exportName}' in module '${modSpec}'`).toBe('function');
+    }
+  });
+
+  it('bare handlersPath sequences export handlers and include all referenced beat.handler names', async () => {
+    const seqRoot = path.join(publicDir, 'json-sequences');
+    expect(fs.existsSync(seqRoot)).toBe(true);
+
+    const dirs = fs.readdirSync(seqRoot).filter((d) => fs.statSync(path.join(seqRoot, d)).isDirectory());
+
+    // For each catalog dir, if it has an index.json, load it and check entries with bare handlersPath
+    for (const dir of dirs) {
+      const indexPath = path.join(seqRoot, dir, 'index.json');
+      if (!fs.existsSync(indexPath)) continue;
+
+      const indexJson = JSON.parse(fs.readFileSync(indexPath, 'utf-8')) as any;
+      const sequences = Array.isArray(indexJson?.sequences) ? indexJson.sequences : [];
+
+      for (const ent of sequences) {
+        const handlersPath = (ent && ent.handlersPath) || '';
+        if (!handlersPath || !isBareSpecifier(String(handlersPath))) continue; // only bare specs
+
+        const spec = normalizeHandlersImportSpec(false, String(handlersPath));
+        const mod: any = await import(spec);
+        const handlers = mod?.handlers || mod?.default?.handlers;
+        expect(!!handlers, `handlers export not found at '${handlersPath}' for catalog '${dir}'`).toBe(true);
+
+        // Load the sequence JSON and validate handler names exist
+        const file = String(ent.file || '').trim();
+        const seqPath = path.join(seqRoot, dir, file);
+        expect(fs.existsSync(seqPath), `Missing sequence file '${file}' for catalog '${dir}'`).toBe(true);
+        const seq = JSON.parse(fs.readFileSync(seqPath, 'utf-8')) as any;
+
+        const beats: any[] = [];
+        const movements: any[] = Array.isArray(seq?.movements) ? seq.movements : [];
+        for (const m of movements) {
+          const b = Array.isArray(m?.beats) ? m.beats : [];
+          beats.push(...b);
+        }
+
+        const referenced = Array.from(
+          new Set(
+            beats
+              .map((b: any) => String(b?.handler || '').trim())
+              .filter((name) => !!name)
+          )
+        );
+
+        const missing = referenced.filter((name) => !(name in (handlers || {})));
+        const seqId = String(seq?.id || file);
+        expect(missing.length, `Missing handler(s) [${missing.join(', ')}] in '${handlersPath}' for sequence '${seqId}'`).toBe(0);
+      }
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
Add guardrail tests to verify externalized plugins (loaded via bare package specifiers) correctly export:
- A runtime registration function as declared in plugin-manifest (e.g., `runtime: { module, export: "register" }`)
- A `handlers` object for JSON-mounted sequences whose `handlersPath` points at a package (e.g., `@renderx-plugins/library-component`), and that all referenced `beat.handler` names exist in that object

## Changes
- New test: `__tests__/manifest/valid-external-handlers.spec.ts`
  - Loads `public/plugins/plugin-manifest.json` and asserts runtime exports for bare package plugins are callable
  - Scans `public/json-sequences/**/index.json` for entries with bare `handlersPath`, dynamically imports the package, asserts `handlers` exists, and checks that every referenced `beat.handler` name is present
  - Uses `normalizeHandlersImportSpec(false, spec)` and `isBareSpecifier()` from `src/handlersPath.ts` to mirror host import behavior

## Why
Addresses issue #130 by preventing silent mounts with `handler=?` or no-op sequences when external packages export incorrectly. This complements existing ESLint rules which only validate repo-local handler paths.

## Validation
- Lint: passed (`npm run lint`)
- Tests: full suite passed locally (`npm test`) including the new guardrail spec
- Build: passed (`npm run build`) per repo rule to run build before commit

## Notes
- The test runs against public artifacts, working in both dev and artifact modes as they’re generated by pre:manifests.
- Clear failure messages identify the plugin, module, and missing handlers.

Resolves #130.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author