### PR TITLE
feat(#129): Phase 1 — Canvas externalization groundwork (ADR-0028 status update)

### DIFF
--- a/docs/adr/ADR-0028 — Canvas Externalization — Canvas UI and Canvas-Component Runtime Registration.md
+++ b/docs/adr/ADR-0028 — Canvas Externalization — Canvas UI and Canvas-Component Runtime Registration.md
@@ -39,3 +39,11 @@ Other plugins (Header, Library, Library-Component) already follow this pattern. 
 - Publish @renderx-plugins/canvas-component independently and move re-exports to true external package entry points.
 - Extend guardrails to assert no duplicate JSON mounts when registerAllSequences runs multiple times.
 
+
+
+## Status update — 2025-09-13
+- Phase 1 kicked off under issue #129.
+- Packages exist in-repo: `@renderx-plugins/canvas` (UI) and `@renderx-plugins/canvas-component` (runtime).
+- Idempotent `register(conductor)` guards implemented; sequence mounting remains via JSON catalogs.
+- Package-local tests added (export surfaces, register idempotency) — green.
+- CI E2E stabilized and green; next is host-level tests validating manifest routing and PanelSlot loading by specifier.

--- a/packages/renderx-plugin-canvas-component/__tests__/package.register.spec.ts
+++ b/packages/renderx-plugin-canvas-component/__tests__/package.register.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as pkg from '../src/index';
+
+function createFakeConductor() {
+  const mounted: any[] = [];
+  return {
+    mounted,
+    logger: { warn: vi.fn(), info: vi.fn() },
+    async mount(seq: any, _handlers: any, pluginId: string) {
+      mounted.push({ seq, pluginId });
+    },
+  } as any;
+}
+
+describe('@renderx-plugins/canvas-component: package surface + register()', () => {
+  it('exposes handlers and a register(conductor) function', async () => {
+    expect(typeof (pkg as any).handlers).toBe('object');
+    expect(typeof (pkg as any).register).toBe('function');
+  });
+
+  it('register() is idempotent and sets a guard on the conductor', async () => {
+    const c = createFakeConductor();
+    await (pkg as any).register(c);
+    await (pkg as any).register(c); // call twice — should be harmless
+
+    // Guard is set only once
+    expect((c as any)._canvasComponentRegistered).toBe(true);
+  });
+});
+

--- a/packages/renderx-plugin-canvas/__tests__/ui.export.spec.ts
+++ b/packages/renderx-plugin-canvas/__tests__/ui.export.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import * as pkg from '../src/index';
+
+describe('@renderx-plugins/canvas: UI export + register()', () => {
+  it('exports CanvasPage and register()', async () => {
+    expect(typeof (pkg as any).CanvasPage).toBe('function');
+    expect(typeof (pkg as any).register).toBe('function');
+  });
+});
+


### PR DESCRIPTION
This PR kicks off Phase 1 of Canvas externalization (issue #129) with documentation and planning changes:

What’s included
- docs/adr: ADR-0028 status update — Phase 1 kickoff and current progress
  - Confirms in-repo packages: `@renderx-plugins/canvas` (UI) and `@renderx-plugins/canvas-component` (runtime)
  - Documents idempotent `register(conductor)` guard and reliance on JSON catalogs for sequence mounting
  - Notes CI E2E stability and upcoming host-level tests

Context
- CI is green on main after recent E2E stabilizations. Canvas packages exist and build via tsup; initial package-level tests are green.
- The next changes in this PR series will add host-level tests to validate:
  - Registration + manifest routing by package specifier
  - PanelSlot loads UI by specifier
  - No duplicate mounts when JSON loader and runtime register coexist

Plan (Phase 1 checklist excerpt)
- [x] Packages exist and build with tsup
- [x] Initial runtime register guard in canvas-component
- [x] Package-local tests (export surfaces, idempotent register)
- [ ] Host manifests: verify specifier usage; remove any repo-relative handlers
- [ ] Host tests: registration + manifest routing + PanelSlot loading

Notes
- ADR-0028 remains the source of truth for architecture decisions and links to #129.
- Subsequent commits on this branch will be TDD-first (tests → implementation → refactor) for the remaining Phase 1 items.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author