### PR TITLE
fix(#144): Control Panel selection notify uses package observer store

### DIFF
--- a/__tests__/control-panel/selection.package-notify.observer.spec.ts
+++ b/__tests__/control-panel/selection.package-notify.observer.spec.ts
@@ -1,0 +1,35 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { handlers as packageSelectionHandlers } from "../..//packages/control-panel/src/symphonies/selection/selection.symphony";
+import { setSelectionObserver } from "../../packages/control-panel/src/state/observer.store";
+
+describe("Control Panel (package) selection notify -> observer store", () => {
+  beforeEach(() => {
+    // ensure clean observer state
+    setSelectionObserver(null);
+  });
+  afterEach(() => {
+    setSelectionObserver(null);
+  });
+
+  it("calls the package observer store when notifyUi runs", () => {
+    const observer = vi.fn();
+    setSelectionObserver(observer);
+
+    const selectionModel = {
+      header: { type: "button", id: "rx-node-test" },
+      content: { content: "Click me", variant: "primary", size: "medium", disabled: false },
+      layout: { x: 50, y: 30, width: 120, height: 40 },
+      styling: { "bg-color": "#007acc", "text-color": "#ffffff" },
+      classes: ["rx-comp", "rx-button"],
+    };
+
+    const ctx: any = { payload: { selectionModel }, logger: { warn: vi.fn() } };
+
+    packageSelectionHandlers.notifyUi({}, ctx);
+
+    expect(observer).toHaveBeenCalledTimes(1);
+    expect(observer).toHaveBeenCalledWith(selectionModel);
+  });
+});
+

--- a/packages/control-panel/src/symphonies/selection/selection.symphony.ts
+++ b/packages/control-panel/src/symphonies/selection/selection.symphony.ts
@@ -1,1 +1,22 @@
-export { handlers } from '../../../../../plugins/control-panel/symphonies/selection/selection.symphony';
+import { deriveSelectionModel } from "./selection.stage-crew";
+import { getSelectionObserver } from "../../state/observer.store";
+
+// NOTE: Runtime sequences are mounted from JSON (see json-sequences/*). This file only exports handlers.
+
+export const handlers = {
+  deriveSelectionModel,
+  notifyUi(_data: any, ctx: any) {
+    const observer = getSelectionObserver();
+    const selectionModel = ctx.payload?.selectionModel;
+
+    if (observer && selectionModel) {
+      try {
+        observer(selectionModel);
+      } catch (e) {
+        ctx.logger?.warn?.("Control Panel selection observer error:", e);
+      }
+    }
+    // IMPORTANT: Do not republish the 'canvas.component.selection.changed' topic here.
+    // This symphony is triggered BY that topic; republishing would cause a loop.
+  },
+};


### PR DESCRIPTION
Summary
- Fix Control Panel UI not updating on selection after guardrails merge
- Root cause: package selection symphony was re-exporting handlers from plugins/control-panel, which uses a different observer store instance than the package UI
- Change: implement handlers locally in packages/control-panel/src/symphonies/selection/selection.symphony.ts to use the package observer store
- Added test: __tests__/control-panel/selection.package-notify.observer.spec.ts (verifies notifyUi calls package observer)

Validation
- Build: npm run build → OK
- Tests: 235 total (234 passed, 1 skipped)
- Startup E2E guardrail: no critical startup errors

Notes
- References regression under #144 (Decouple Control Panel): selection notify handler now correctly calls the package-local observer

Checklist
- [x] Lint/build/tests green locally
- [x] Linked to issue #144
- [x] Minimal scope (single file change + focused test)


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author