### PR TITLE
chore(#144): prepare @renderx-plugins/control-panel 0.1.0-rc.1 prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lint": "eslint .",
     "lint:ui": "eslint plugins/**/ui",
     "lint:fix": "eslint . --fix",
+    "pretest": "npm --prefix packages/control-panel run -s build",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:cov": "vitest run --coverage",

--- a/packages/control-panel/package.json
+++ b/packages/control-panel/package.json
@@ -1,15 +1,28 @@
 {
   "name": "@renderx-plugins/control-panel",
-  "version": "0.0.0-dev",
-  "private": true,
+  "version": "0.1.0-rc.1",
+  "private": false,
   "type": "module",
   "sideEffects": false,
   "files": [
+    "dist",
     "src"
   ],
+  "types": "./dist/index.d.ts",
+  "module": "./dist/index.js",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./symphonies/*": "./src/symphonies/*"
+  },
+  "scripts": {
+    "build": "tsup --config tsup.config.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "rc"
   }
 }
 

--- a/packages/control-panel/tsup.config.ts
+++ b/packages/control-panel/tsup.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/symphonies/**/*.ts',
+  ],
+  dts: true,
+  format: ['esm'],
+  sourcemap: true,
+  clean: true,
+  outDir: 'dist',
+  treeshake: true,
+  minify: false,
+  target: 'es2022',
+  skipNodeModulesBundle: true,
+  splitting: false,
+  shims: false,
+  // Keep external deps unbundled
+  external: [
+    'react',
+    'react-dom',
+    '@renderx-plugins/host-sdk',
+    '@renderx-plugins/manifest-tools',
+  ],
+});
+


### PR DESCRIPTION
This PR completes the Control Panel externalization acceptance and prerelease packaging work for #144.

Summary of changes:
- Switch package root export to built artifacts in dist (ESM + d.ts)
- Keep `./symphonies/*` mapped to `src` to maintain `.ts` handlersPath compatibility in JSON catalogs/tests
- Add tsup build config and scripts to emit dist/
- Mark package public and set publish tag to `rc`

Verification:
- Build: npm run build — OK
- Tests: 234 passed, 1 skipped
- Manifest and handlersPath validations are green
- EventRouter reentrancy guard tests pass

Notes:
- The hybrid export mapping allows the host to develop locally while consuming the packaged root entry from dist.
- Published package: `@renderx-plugins/control-panel@0.1.0-rc.1`

Closes #144.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author