### PR TITLE
chore(#159): enforce Control Panel externalization — remove host fallback; guardrails + package tests; ADR-0031

### DIFF
--- a/__tests__/guardrails/control-panel.externalization.guardrail.spec.ts
+++ b/__tests__/guardrails/control-panel.externalization.guardrail.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+describe('Control Panel externalization guardrails', () => {
+  it('does not include host fallback to internal /plugins/control-panel/index.ts', () => {
+    const p = path.join(process.cwd(), 'src', 'conductor.ts');
+    const txt = readFileSync(p, 'utf-8');
+    expect(txt).not.toMatch(/\/plugins\/control-panel\/index\.ts/);
+  });
+
+  it('plugin-manifest points ControlPanelPlugin to the package', () => {
+    const manifestPath = path.join(process.cwd(), 'public', 'plugins', 'plugin-manifest.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+    const cp = (manifest.plugins || []).find((p: any) => p?.id === 'ControlPanelPlugin');
+    expect(cp).toBeTruthy();
+    expect(cp.ui?.module).toBe('@renderx-plugins/control-panel');
+    expect(cp.runtime?.module).toBe('@renderx-plugins/control-panel');
+  });
+});
+

--- a/docs/adr/ADR-0031 — Control Panel Externalization Follow-Through — Boundary Enforcement.md
+++ b/docs/adr/ADR-0031 — Control Panel Externalization Follow-Through — Boundary Enforcement.md
@@ -1,0 +1,36 @@
+# ADR-0031 — Control Panel Externalization Follow-Through — Boundary Enforcement
+
+Status: Accepted
+Date: 2025-09-17
+Related Issue: #159
+Related ADRs: ADR-0030, ADR-0020, ADR-0025
+
+## Context
+We externalized the Control Panel into the workspace npm package `@renderx-plugins/control-panel` and updated plugin-manifest and JSON sequence catalogs to use bare package specifiers. A legacy host fallback still allowed loading the internal path `/plugins/control-panel/index.ts`, which weakens boundary guarantees and risks regressions where the host accidentally couples to internal plugin sources.
+
+## Decision
+- Remove the host runtime fallback mapping for `/plugins/control-panel/index.ts`.
+- Enforce package consumption via statically-known loader for `@renderx-plugins/control-panel` only.
+- Add guardrail tests:
+  - Assert no `/plugins/control-panel/index.ts` fallback is present in `src/conductor.ts`.
+  - Assert the manifest points to `@renderx-plugins/control-panel` for both UI and runtime.
+- Add package smoke tests to ensure the package exports are stable (UI export and a symphony `handlers` export).
+
+## Consequences
+- Hardens boundaries: host cannot accidentally import internal Control Panel sources.
+- CI now fails if a fallback is reintroduced or the manifest regresses to path-based modules.
+- The internal `plugins/control-panel` directory remains only as legacy source; it can be removed in a separate cleanup once downstream consumers are verified.
+
+## Alternatives Considered
+- Keep the fallback until all consumers migrate: rejected to avoid split-brain behavior and silent coupling.
+- ESLint-only enforcement: added tests provide stronger guarantees and catch non-lint regressions.
+
+## Work Items
+- Update `src/conductor.ts` to drop the internal path fallback.
+- Add `__tests__/guardrails/control-panel.externalization.guardrail.spec.ts`.
+- Add `packages/control-panel/__tests__/exports.spec.ts`.
+- Ensure build and full test suite pass.
+
+## Rollback Plan
+If an unforeseen environment requires the internal fallback, the mapping can be reintroduced temporarily behind a feature flag; however, prefer fixing the environment to resolve the package properly.
+

--- a/packages/control-panel/__tests__/exports.spec.ts
+++ b/packages/control-panel/__tests__/exports.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+
+import { ControlPanel, register } from '@renderx-plugins/control-panel';
+import { handlers as selectionHandlers } from '@renderx-plugins/control-panel/symphonies/selection/selection.symphony';
+
+describe('@renderx-plugins/control-panel package exports', () => {
+  it('exports ControlPanel UI component', () => {
+    expect(typeof ControlPanel).toBe('function');
+  });
+
+  it('exports register() function (no-op allowed)', () => {
+    expect(typeof register).toBe('function');
+  });
+
+  it('exports selection symphony handlers', () => {
+    expect(selectionHandlers && typeof selectionHandlers).toBe('object');
+    expect(typeof selectionHandlers.deriveSelectionModel).toBe('function');
+    expect(typeof selectionHandlers.notifyUi).toBe('function');
+  });
+});
+

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -35,7 +35,7 @@ const runtimePackageLoaders: Record<string, () => Promise<any>> = {
   // Resolve Control Panel via workspace npm package during migration
   '@renderx-plugins/control-panel': () => import('@renderx-plugins/control-panel'),
   // Pre-bundled first-party fallback for yet-internal plugins
-  '/plugins/control-panel/index.ts': () => import('../plugins/control-panel/index'),
+
 };
 
 


### PR DESCRIPTION
Fixes #159

Summary
- Enforce consuming Control Panel via workspace/npm package only
- Remove host fallback mapping to /plugins/control-panel
- Add guardrail to prevent reintroduction of host fallback
- Add package-level smoke tests to assert stable exports
- Add ADR-0031 documenting the boundary decision and consequences

Key changes
- src/conductor.ts: remove internal path fallback; only load '@renderx-plugins/control-panel'
- __tests__/guardrails/control-panel.externalization.guardrail.spec.ts: asserts no host fallback and manifest points to package
- packages/control-panel/__tests__/exports.spec.ts: smoke tests for ControlPanel UI export, register(), and selection symphony handlers
- docs/adr/ADR-0031 — Control Panel Externalization Follow-Through — Boundary Enforcement.md: architecture decision record

Verification
- Built before commit (repo rule) — success
- Full test run on Windows — success
  - 243 passed | 1 skipped | 0 failed (latest local)
- Guardrail test ensures no regression back to host fallback

Notes
- This PR continues Step 4 of the agreed plan (Control Panel externalization follow‑through)
- No dependency changes

Checklist
- [x] Linked to issue #159
- [x] ADR included (ADR-0031)
- [x] Tests updated/added and passing
- [x] Build passes locally

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author