### PR TITLE
chore(#159): move Control Panel unit/smoke tests into package

### DIFF
--- a/packages/control-panel/__tests__/dark-mode-form-controls.spec.tsx
+++ b/packages/control-panel/__tests__/dark-mode-form-controls.spec.tsx
@@ -217,3 +217,4 @@ describe("Control Panel Dark Mode Form Controls", () => {
     expect(checkboxText.classList.contains("checkbox-text")).toBe(true);
   });
 });
+

--- a/packages/control-panel/__tests__/html.code-editor.fallback.spec.ts
+++ b/packages/control-panel/__tests__/html.code-editor.fallback.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { SchemaResolverService } from "../../plugins/control-panel/services/schema-resolver.service";
+import { SchemaResolverService } from "../src/services/schema-resolver.service";
 import type {
   ControlPanelConfig,
   SelectedElement,
-} from "../../plugins/control-panel/types/control-panel.types";
-import htmlSchemaOriginal from "../../json-components/html.json";
+} from "../src/types/control-panel.types";
+import htmlSchemaOriginal from "../../../json-components/html.json";
 
 const baseConfig: ControlPanelConfig = {
   version: "1.0.0-test",
@@ -13,7 +13,7 @@ const baseConfig: ControlPanelConfig = {
     {
       id: "content",
       title: "Content",
-      icon: "🧩",
+      icon: "\ud83e\udde9",
       order: 1,
       collapsible: true,
       defaultExpanded: true,
@@ -21,7 +21,7 @@ const baseConfig: ControlPanelConfig = {
     {
       id: "layout",
       title: "Layout",
-      icon: "📐",
+      icon: "\ud83d\udcd0",
       order: 2,
       collapsible: true,
       defaultExpanded: true,
@@ -29,7 +29,7 @@ const baseConfig: ControlPanelConfig = {
     {
       id: "styling",
       title: "Styling",
-      icon: "🎨",
+      icon: "\ud83c\udfa8",
       order: 3,
       collapsible: true,
       defaultExpanded: false,
@@ -44,11 +44,11 @@ describe("HTML component markup field fallback", () => {
     const resolver = new SchemaResolverService(baseConfig);
     const stale = JSON.parse(JSON.stringify(htmlSchemaOriginal)) as any;
     // Simulate outdated schema without ui.control metadata
-    delete stale.integration.properties.schema.markup.ui;
+    delete (stale as any).integration.properties.schema.markup.ui;
     resolver.registerComponentSchema("html", stale);
 
     const element: SelectedElement = {
-      header: { id: "2", type: "html", name: "HTML", version: "1.0.1" },
+      header: { id: "2", type: "html", name: "HTML", version: "1.0.1" } as any,
       content: { markup: "<p>Test</p>" },
       layout: { x: 0, y: 0, width: 320, height: 120 },
       styling: {},
@@ -60,3 +60,4 @@ describe("HTML component markup field fallback", () => {
     expect(markupField?.rendererProps?.rows).toBe(8);
   });
 });
+

--- a/packages/control-panel/__tests__/html.code-editor.mapping.spec.ts
+++ b/packages/control-panel/__tests__/html.code-editor.mapping.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { SchemaResolverService } from "../../plugins/control-panel/services/schema-resolver.service";
+import { SchemaResolverService } from "../src/services/schema-resolver.service";
 import type {
   ControlPanelConfig,
   SelectedElement,
-} from "../../plugins/control-panel/types/control-panel.types";
-import htmlSchema from "../../json-components/html.json";
+} from "../src/types/control-panel.types";
+import htmlSchema from "../../../json-components/html.json";
 
 const baseConfig: ControlPanelConfig = {
   version: "1.0.0-test",
@@ -46,7 +46,7 @@ describe("HTML component markup field", () => {
     resolver.registerComponentSchema("html", htmlSchema as any);
 
     const element: SelectedElement = {
-      header: { id: "1", type: "html", name: "HTML", version: "1.0.0" },
+      header: { id: "1", type: "html", name: "HTML", version: "1.0.0" } as any,
       content: { markup: "<p>Test</p>" },
       layout: { x: 0, y: 0, width: 300, height: 120 },
       styling: {},
@@ -59,3 +59,4 @@ describe("HTML component markup field", () => {
     expect(markupField?.rendererProps?.rows).toBe(8);
   });
 });
+

--- a/packages/control-panel/__tests__/observer.store.spec.ts
+++ b/packages/control-panel/__tests__/observer.store.spec.ts
@@ -7,7 +7,7 @@ import {
   setCssRegistryObserver,
   getCssRegistryObserver,
   clearAllObservers,
-} from "../../plugins/control-panel/state/observer.store";
+} from "@renderx-plugins/control-panel/observer.store";
 
 describe("observer.store idempotency", () => {
   it("setters are idempotent and clearAll resets observers", () => {

--- a/packages/control-panel/__tests__/schema-resolver.memo.spec.ts
+++ b/packages/control-panel/__tests__/schema-resolver.memo.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { SchemaResolverService } from "../../plugins/control-panel/services/schema-resolver.service";
+import { SchemaResolverService } from "../src/services/schema-resolver.service";
 
 // Minimal config shape needed by constructor
 const config: any = {

--- a/packages/control-panel/__tests__/svg.code-editor.mapping.spec.ts
+++ b/packages/control-panel/__tests__/svg.code-editor.mapping.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
-import { SchemaResolverService } from "../../plugins/control-panel/services/schema-resolver.service";
-import type { ControlPanelConfig, SelectedElement, ComponentSchema } from "../../plugins/control-panel/types/control-panel.types";
+import { SchemaResolverService } from "../src/services/schema-resolver.service";
+import type { ControlPanelConfig, SelectedElement, ComponentSchema } from "../src/types/control-panel.types";
 
 function loadJson<T = any>(p: string): T {
   const txt = fs.readFileSync(p, "utf-8");
@@ -11,9 +11,12 @@ function loadJson<T = any>(p: string): T {
 
 describe("SVG schema → code editor mapping", () => {
   it("maps ui.control = code to field.type = 'code' and applies preserveAspectRatio enum presets", async () => {
-    const root = path.resolve(__dirname, "../../");
-    const config = loadJson<ControlPanelConfig>(path.join(root, "plugins/control-panel/config/control-panel.schema.json"));
-    const svgSchema = loadJson<ComponentSchema>(path.join(root, "json-components/svg.json"));
+    const configPath = path.join(__dirname, "..", "src", "config", "control-panel.schema.json");
+    const repoRoot = path.resolve(__dirname, "..", "..", "..");
+    const svgSchemaPath = path.join(repoRoot, "json-components", "svg.json");
+
+    const config = loadJson<ControlPanelConfig>(configPath);
+    const svgSchema = loadJson<ComponentSchema>(svgSchemaPath);
 
     const resolver = new SchemaResolverService(config);
     resolver.registerComponentSchema("svg", svgSchema);


### PR DESCRIPTION
This follow-up PR for issue #159 completes the Control Panel externalization by moving unit/smoke tests into the package workspace.

What changed
- Moved Control Panel tests from repo root to the package:
  - __tests__/control-panel/* → packages/control-panel/__tests__/*
    - dark-mode-form-controls.spec.tsx
    - html.code-editor.fallback.spec.ts
    - html.code-editor.mapping.spec.ts
    - observer.store.spec.ts
    - schema-resolver.memo.spec.ts
    - svg.code-editor.mapping.spec.ts
- Left host-level integration/E2E + guardrail tests in the root (PanelSlot integration, EventRouter guardrails, startup guardrail, manifest/externalization guardrails).

Why
- Aligns with plugin externalization plan: package-scoped unit/smoke/manifest tests live with the plugin; only host integration and guardrails remain at root.
- Matches the pattern we established for @renderx-plugins/library.

Verification
- Ran build before commit (per repo rule) and full test suite after the move. Results: all tests passing locally with existing skip(s) unchanged.

Next steps (optional, separate PRs)
- Add ESLint guardrails inside the package (no host internals; only allow SDK/manifest-tools/React) with rule tests.
- Ensure CI executes package tests explicitly if not already covered by workspace test runner.

Refs: #159

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author