### PR TITLE
feat(test-harness): Phase 1: Test Harness + Protocol (Plugin‑Served, Data‑Driven E2E)

### DIFF
--- a/src/test-harness/harness.ts
+++ b/src/test-harness/harness.ts
@@ -1,0 +1,210 @@
+import { CHANNEL, PROTOCOL_VERSION, isMessage } from './protocol';
+import type { TestHarnessAPI, Step, Assert, StepResult, AssertResult, LogEntry } from './types';
+
+// Simple correlation counter for steps/asserts
+let nextId = 1;
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const to = setTimeout(() => reject(new Error(`Timeout waiting for ${label} after ${ms}ms`)), ms);
+    p.then(v => { clearTimeout(to); resolve(v); }, e => { clearTimeout(to); reject(e); });
+  });
+}
+
+class Harness implements TestHarnessAPI {
+  private iframe: HTMLIFrameElement | null = null;
+  private targetOrigin: string = '*';
+  private logs: LogEntry[] = [];
+  private readyPhases = new Set<number>();
+  private driverVersion: string | null = null;
+  private capabilities: string[] = [];
+
+  constructor() {
+    window.addEventListener('message', (event) => {
+      const data = event.data;
+      if (!isMessage(data)) return;
+      // Optionally enforce origin based on iframe src
+      if (this.iframe && event.source !== this.iframe.contentWindow) return;
+      this.log('driver', data.type, data.payload);
+      if (data.type === 'driver:readyPhase') {
+        const ph = (data.payload && data.payload.phase) ?? null;
+        if (typeof ph === 'number') this.readyPhases.add(ph);
+      }
+    });
+  }
+
+  private post(type: string, payload?: any) {
+    const msg = { channel: CHANNEL, version: PROTOCOL_VERSION, type, payload };
+    this.log('host', type, payload);
+    this.iframe?.contentWindow?.postMessage(msg, this.targetOrigin);
+  }
+
+  private log(dir: 'host' | 'driver', type: string, payload?: any) {
+    this.logs.push({ t: Date.now(), dir, type, payload });
+    // keep last N
+    if (this.logs.length > 1000) this.logs.splice(0, this.logs.length - 1000);
+  }
+
+  async load(driverUrl: string, scenario: { id: string; env?: Record<string, any>; flags?: Record<string, any> }) {
+    // Create iframe lazily or reset existing
+    if (this.iframe) {
+      await this.teardown();
+    }
+    this.readyPhases.clear();
+    const iframe = document.createElement('iframe');
+    iframe.src = driverUrl;
+    iframe.style.width = '100%';
+    iframe.style.height = '800px';
+    iframe.style.border = '1px solid var(--border-color, #ccc)';
+    document.body.appendChild(iframe);
+    this.iframe = iframe;
+    this.targetOrigin = '*';
+
+    // Wait for contentWindow
+    await new Promise<void>((resolve) => {
+      if (iframe.contentWindow) return resolve();
+      iframe.addEventListener('load', () => resolve());
+    });
+
+    // Send init
+    this.post('host:init', { scenarioId: scenario.id, env: scenario.env ?? {}, flags: scenario.flags ?? {} });
+
+    // Wait for driver:ack with capabilities
+    await withTimeout(new Promise<void>((resolve) => {
+      const onMsg = (event: MessageEvent) => {
+        const data = event.data;
+        if (!isMessage(data)) return;
+        if (data.type === 'driver:ack') {
+          this.driverVersion = data.payload?.driverVersion ?? null;
+          this.capabilities = Array.isArray(data.payload?.capabilities) ? data.payload.capabilities : [];
+          window.removeEventListener('message', onMsg as any);
+          resolve();
+        }
+      };
+      window.addEventListener('message', onMsg as any);
+    }), 5000, 'driver ack');
+  }
+
+  async waitForReadyPhases(phases: number[], timeoutMs: number = 10000) {
+    // Wait sequentially to ensure order
+    const start = Date.now();
+    for (const ph of phases) {
+      const remaining = Math.max(1, timeoutMs - (Date.now() - start));
+      await withTimeout(new Promise<void>((resolve) => {
+        if (this.readyPhases.has(ph)) return resolve();
+        const onMsg = (event: MessageEvent) => {
+          const data = event.data;
+          if (!isMessage(data)) return;
+          if (data.type === 'driver:readyPhase' && data.payload?.phase === ph) {
+            window.removeEventListener('message', onMsg as any);
+            resolve();
+          }
+        };
+        window.addEventListener('message', onMsg as any);
+      }), remaining, `ready phase ${ph}`);
+    }
+  }
+
+  async runSteps(steps: Step[], timeoutPerStepMs = 8000): Promise<StepResult[]> {
+    const results: StepResult[] = [];
+    for (const step of steps || []) {
+      const id = nextId++;
+      const res = await withTimeout(new Promise<StepResult>((resolve) => {
+        const onMsg = (event: MessageEvent) => {
+          const data = event.data;
+          if (!isMessage(data)) return;
+          if (data.type === 'driver:stepResult' && data.payload?.id === id) {
+            window.removeEventListener('message', onMsg as any);
+            resolve(data.payload as StepResult);
+          }
+        };
+        window.addEventListener('message', onMsg as any);
+        this.post('host:step', { id, type: step.type, payload: step.payload });
+      }), timeoutPerStepMs, `step ${step.type}`);
+      results.push(res);
+    }
+    return results;
+  }
+
+  async runAsserts(asserts: Assert[], timeoutPerAssertMs = 8000): Promise<AssertResult[]> {
+    const results: AssertResult[] = [];
+    for (const a of asserts || []) {
+      const id = nextId++;
+      const res = await withTimeout(new Promise<AssertResult>((resolve) => {
+        const onMsg = (event: MessageEvent) => {
+          const data = event.data;
+          if (!isMessage(data)) return;
+          if (data.type === 'driver:assertResult' && data.payload?.id === id) {
+            window.removeEventListener('message', onMsg as any);
+            resolve(data.payload as AssertResult);
+          }
+        };
+        window.addEventListener('message', onMsg as any);
+        this.post('host:assert', { id, type: a.type, payload: a });
+      }), timeoutPerAssertMs, `assert ${a.type}`);
+      results.push(res);
+    }
+    return results;
+  }
+
+  async getSnapshot(): Promise<any | null> {
+    return await withTimeout(new Promise<any>((resolve) => {
+      const onMsg = (event: MessageEvent) => {
+        const data = event.data;
+        if (!isMessage(data)) return;
+        if (data.type === 'driver:snapshot') {
+          window.removeEventListener('message', onMsg as any);
+          resolve(data.payload?.state ?? null);
+        }
+      };
+      window.addEventListener('message', onMsg as any);
+      this.post('host:snapshot');
+    }), 4000, 'snapshot');
+  }
+
+  getLogs(): LogEntry[] {
+    return [...this.logs];
+  }
+
+  async teardown(): Promise<void> {
+    if (!this.iframe) return;
+    try {
+      await withTimeout(new Promise<void>((resolve) => {
+        const onMsg = (event: MessageEvent) => {
+          const data = event.data;
+          if (!isMessage(data)) return;
+          if (data.type === 'driver:teardownResult') {
+            window.removeEventListener('message', onMsg as any);
+            resolve();
+          }
+        };
+        window.addEventListener('message', onMsg as any);
+        this.post('host:teardown');
+      }), 3000, 'teardown');
+    } catch {}
+    this.iframe.remove();
+    this.iframe = null;
+    this.readyPhases.clear();
+  }
+}
+
+// Attach to window
+(function attach() {
+  const h = new Harness();
+  (globalThis as any).TestHarness = h;
+  // Optional: auto-init when query has driver & scenario
+  try {
+    const usp = new URLSearchParams(globalThis.location.search);
+    const driver = usp.get('driver');
+    const scenarioId = usp.get('scenario');
+    const phases = usp.get('phases');
+    const timeout = parseInt(usp.get('timeout') || '8000', 10);
+    if (driver && scenarioId) {
+      h.load(driver, { id: scenarioId }).then(async () => {
+        const arr = phases ? phases.split(',').map(n => parseInt(n, 10)).filter(n => !isNaN(n)) : [0,1,2];
+        await h.waitForReadyPhases(arr, timeout);
+        // No-op after ready; consumers can interact via page.evaluate in tests
+      });
+    }
+  } catch {}
+})();

--- a/src/test-harness/protocol.ts
+++ b/src/test-harness/protocol.ts
@@ -1,0 +1,33 @@
+// Message protocol envelope and helpers
+
+export const CHANNEL = 'rx.test';
+export const PROTOCOL_VERSION = '1.0.0';
+
+export type HostToDriverType =
+  | 'host:init'
+  | 'host:step'
+  | 'host:assert'
+  | 'host:snapshot'
+  | 'host:teardown';
+
+export type DriverToHostType =
+  | 'driver:ack'
+  | 'driver:readyPhase'
+  | 'driver:stepResult'
+  | 'driver:assertResult'
+  | 'driver:snapshot'
+  | 'driver:teardownResult'
+  | 'driver:log';
+
+export interface Message<TType extends string = string, TPayload = any> {
+  channel: typeof CHANNEL;
+  version: typeof PROTOCOL_VERSION;
+  type: TType;
+  payload?: TPayload;
+}
+
+export function isMessage(obj: any): obj is Message {
+  return !!obj && obj.channel === CHANNEL && typeof obj.type === 'string';
+}
+
+export function now() { return Date.now(); }

--- a/src/test-harness/types.ts
+++ b/src/test-harness/types.ts
@@ -1,0 +1,73 @@
+// Shared types for plugin-served, data-driven E2E
+
+export type TestApiVersion = string; // semver string, e.g., "1.0.0"
+
+export interface TestManifest {
+  testApiVersion: TestApiVersion;
+  plugin: { id: string; version: string };
+  driverUrl: string; // e.g., "/test/driver.html"
+  capabilities?: string[];
+  scenarios: TestScenario[];
+}
+
+export interface EnvHints {
+  viewport?: { width: number; height: number };
+  theme?: 'light' | 'dark';
+  [key: string]: unknown;
+}
+
+export interface ReadinessSpec {
+  phases: number[]; // e.g., [0,1,2]
+  timeoutMs?: number;
+}
+
+export interface TestScenario {
+  id: string;
+  title?: string;
+  tags?: string[];
+  readiness?: ReadinessSpec;
+  env?: EnvHints;
+  steps?: Step[];
+  asserts?: Assert[];
+  artifacts?: { screenshot?: boolean; snapshot?: boolean };
+}
+
+export interface Step {
+  type: string;
+  payload?: any;
+}
+
+export interface Assert {
+  type: string;
+  selector?: string;
+  [key: string]: any;
+}
+
+export interface StepResult {
+  id: string | number;
+  status: 'ok' | 'fail';
+  detail?: any;
+}
+
+export interface AssertResult {
+  id: string | number;
+  status: 'ok' | 'fail';
+  detail?: any;
+}
+
+export interface TestHarnessAPI {
+  load(driverUrl: string, scenario: { id: string; env?: EnvHints; flags?: Record<string, any> }): Promise<void>;
+  waitForReadyPhases(phases: number[], timeoutMs?: number): Promise<void>;
+  runSteps(steps: Step[], timeoutPerStepMs?: number): Promise<StepResult[]>;
+  runAsserts(asserts: Assert[], timeoutPerAssertMs?: number): Promise<AssertResult[]>;
+  getSnapshot(): Promise<any | null>;
+  getLogs(): LogEntry[];
+  teardown(): Promise<void>;
+}
+
+export interface LogEntry {
+  t: number; // epoch ms
+  dir: 'host' | 'driver';
+  type: string;
+  payload?: any;
+}

--- a/src/test-plugin-loading.html
+++ b/src/test-plugin-loading.html
@@ -438,5 +438,7 @@
   <body>
     <div id="test-root"></div>
     <script type="module" src="/src/test-plugin-loader.tsx"></script>
+    <!-- Load the generic Test Harness (registers window.TestHarness) -->
+    <script type="module" src="/src/test-harness/harness.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
Summary
Implements Phase 1 of ADR‑0033. Adds a generic test harness and message protocol that allow plugins to serve scenarios and a driver page while the host stays thin. The harness is loaded by test-plugin-loading.html and exposes window.TestHarness for Playwright to drive.

Changes
- Added src/test-harness/types.ts: TestManifest, Scenario, Step/Assert, TestHarnessAPI, LogEntry
- Added src/test-harness/protocol.ts: CHANNEL=rx.test, PROTOCOL_VERSION=1.0.0, message envelope + guard
- Added src/test-harness/harness.ts: postMessage bridge
  - load(driverUrl, scenario), waitForReadyPhases([0,1,2])
  - runSteps/runAsserts with per-call timeouts and id correlation
  - driver:ack capture (driverVersion, capabilities)
  - getSnapshot/getLogs/teardown, last-N log buffer
- Wired harness into test-plugin-loading.html via module import

How it works
- Playwright opens src/test-plugin-loading.html?driver=<url>&scenario=<id>
- Harness iframes driverUrl, sends host:init, waits for driver:ack, then tracks driver:readyPhase 0→1→2
- Steps/asserts are sent with correlated ids; results are awaited with timeouts
- Snapshot and teardown supported; logs are captured for diagnostics

Why
- Establishes the thin-host testing contract with deterministic ready phases and a stable postMessage protocol
- Unblocks Phase 2: generic Playwright runner over plugin manifests

Testing
- npm test: PASS (placeholder spec)
- npm run e2e: PASS (placeholder spec)
- Manual smoke: harness loads without errors; TestHarness available on window

Follow-ups (Phase 2+)
- Phase 2: Generic Playwright runner that discovers plugins (tests/e2e.plugin-registry.local.json) and executes scenarios via TestHarness
- Phase 3: Pilot plugin manifests and driver pages; Gherkin → manifest build flow (optional)
- Phase 0 leftover: Vite dev proxy entries to keep plugin endpoints same-origin during local dev

Acceptance criteria mapping
- Deterministic ready phases support: Done (waitForReadyPhases)
- Protocol and capability negotiation: Done (driver:ack + stored capabilities)
- Thin-host harness with timeouts/logging: Done (harness.ts + postMessage bridge)
