### PR TITLE
feat(#229): auto-generate json-interactions from plugin-served artifacts (Phase 1: .generated)

### DIFF
--- a/catalog/json-interactions/.generated/app.json
+++ b/catalog/json-interactions/.generated/app.json
@@ -1,0 +1,13 @@
+{
+  "plugin": "HeaderThemePlugin",
+  "routes": {
+    "app.ui.theme.get": {
+      "pluginId": "HeaderThemePlugin",
+      "sequenceId": "header-ui-theme-get-symphony"
+    },
+    "app.ui.theme.toggle": {
+      "pluginId": "HeaderThemePlugin",
+      "sequenceId": "header-ui-theme-toggle-symphony"
+    }
+  }
+}

--- a/catalog/json-interactions/.generated/canvas.json
+++ b/catalog/json-interactions/.generated/canvas.json
@@ -1,0 +1,93 @@
+{
+  "plugin": "CanvasComponentPlugin",
+  "routes": {
+    "canvas.component.create": {
+      "pluginId": "CanvasComponentPlugin",
+      "sequenceId": "canvas-component-create-symphony"
+    },
+    "canvas.component.delete": {
+      "pluginId": "CanvasComponentDeletePlugin",
+      "sequenceId": "canvas-component-delete-symphony"
+    },
+    "canvas.component.deselect.all": {
+      "pluginId": "CanvasComponentDeselectionPlugin",
+      "sequenceId": "canvas-component-deselect-all-symphony"
+    },
+    "canvas.component.deselect": {
+      "pluginId": "CanvasComponentDeselectionPlugin",
+      "sequenceId": "canvas-component-deselect-symphony"
+    },
+    "canvas.component.drag.move": {
+      "pluginId": "CanvasComponentDragPlugin",
+      "sequenceId": "canvas-component-drag-symphony"
+    },
+    "canvas.component.export.gif": {
+      "pluginId": "CanvasComponentExportGifPlugin",
+      "sequenceId": "canvas-component-export-gif-symphony"
+    },
+    "canvas.component.export.mp4": {
+      "pluginId": "CanvasComponentExportMp4Plugin",
+      "sequenceId": "canvas-component-export-mp4-symphony"
+    },
+    "canvas.component.export": {
+      "pluginId": "CanvasComponentExportPlugin",
+      "sequenceId": "canvas-component-export-symphony"
+    },
+    "canvas.component.import": {
+      "pluginId": "CanvasComponentImportPlugin",
+      "sequenceId": "canvas-component-import-symphony"
+    },
+    "canvas.line.manip.end": {
+      "pluginId": "CanvasLineManipEndPlugin",
+      "sequenceId": "canvas-line-manip-end-symphony"
+    },
+    "canvas.line.manip.move": {
+      "pluginId": "CanvasLineManipMovePlugin",
+      "sequenceId": "canvas-line-manip-move-symphony"
+    },
+    "canvas.line.manip.start": {
+      "pluginId": "CanvasLineManipStartPlugin",
+      "sequenceId": "canvas-line-manip-start-symphony"
+    },
+    "canvas.component.resize.end": {
+      "pluginId": "CanvasComponentResizeEndPlugin",
+      "sequenceId": "canvas-component-resize-end-symphony"
+    },
+    "canvas.line.resize.end": {
+      "pluginId": "CanvasLineResizeEndPlugin",
+      "sequenceId": "canvas-line-resize-end-symphony"
+    },
+    "canvas.line.resize.move": {
+      "pluginId": "CanvasLineResizeMovePlugin",
+      "sequenceId": "canvas-line-resize-move-symphony"
+    },
+    "canvas.line.resize.start": {
+      "pluginId": "CanvasLineResizeStartPlugin",
+      "sequenceId": "canvas-line-resize-start-symphony"
+    },
+    "canvas.component.resize.move": {
+      "pluginId": "CanvasComponentResizeMovePlugin",
+      "sequenceId": "canvas-component-resize-move-symphony"
+    },
+    "canvas.component.resize.start": {
+      "pluginId": "CanvasComponentResizeStartPlugin",
+      "sequenceId": "canvas-component-resize-start-symphony"
+    },
+    "canvas.component.select": {
+      "pluginId": "CanvasComponentSelectionPlugin",
+      "sequenceId": "canvas-component-select-symphony"
+    },
+    "canvas.component.select.svg.node": {
+      "pluginId": "CanvasComponentSvgNodeSelectionPlugin",
+      "sequenceId": "canvas-component-select-svg-node-symphony"
+    },
+    "canvas.component.update": {
+      "pluginId": "CanvasComponentPlugin",
+      "sequenceId": "canvas-component-update-symphony"
+    },
+    "canvas.component.update.svg.node": {
+      "pluginId": "CanvasComponentSvgNodeUpdatePlugin",
+      "sequenceId": "canvas-component-update-svg-node-symphony"
+    }
+  }
+}

--- a/catalog/json-interactions/.generated/library.json
+++ b/catalog/json-interactions/.generated/library.json
@@ -1,0 +1,21 @@
+{
+  "plugin": "LibraryComponentPlugin",
+  "routes": {
+    "library.container.drop": {
+      "pluginId": "LibraryComponentPlugin",
+      "sequenceId": "library-component-container-drop-symphony"
+    },
+    "library.drag.move": {
+      "pluginId": "LibraryComponentPlugin",
+      "sequenceId": "library-component-drag-symphony"
+    },
+    "library.drop": {
+      "pluginId": "LibraryComponentPlugin",
+      "sequenceId": "library-component-drop-symphony"
+    },
+    "library.load": {
+      "pluginId": "LibraryPlugin",
+      "sequenceId": "library-load-symphony"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "artifacts:ci": "npm run artifacts:build:signed && npm run artifacts:validate:strict && npm run artifacts:verify:signature && npm run public-api:check && npm test && npm run artifacts:pack",
     "validate:public-api": "node scripts/validate-public-api.js",
     "preview": "vite preview",
-    "pre:manifests": "node scripts/sync-json-sources.js --srcRoot=catalog && npm run sync:json-components && node scripts/sync-json-sequences.js --srcRoot=catalog && node scripts/generate-interaction-manifest.js --srcRoot=catalog && node scripts/generate-topics-manifest.js --srcRoot=catalog && node scripts/generate-layout-manifest.js --srcRoot=catalog && node scripts/aggregate-plugins.js && node scripts/sync-plugins.js --srcRoot=catalog && node scripts/sync-control-panel-config.js",
+    "pre:manifests": "node scripts/sync-json-sources.js --srcRoot=catalog && npm run sync:json-components && node scripts/sync-json-sequences.js --srcRoot=catalog && node scripts/generate-json-interactions-from-plugins.js && node scripts/generate-interaction-manifest.js --srcRoot=catalog && node scripts/generate-topics-manifest.js --srcRoot=catalog && node scripts/generate-layout-manifest.js --srcRoot=catalog && node scripts/aggregate-plugins.js && node scripts/sync-plugins.js --srcRoot=catalog && node scripts/sync-control-panel-config.js",
     "pretest": "node scripts/sync-json-sources.js --srcRoot=catalog",
     "sync:json-components": "node scripts/sync-json-components.js --srcRoot=catalog",
     "export:gif": "node scripts/export-svg-to-gif.js",

--- a/scripts/generate-interaction-manifest.js
+++ b/scripts/generate-interaction-manifest.js
@@ -50,18 +50,25 @@ async function readJsonSafe(path) {
 }
 
 async function readPluginCatalogs() {
-  const dir = join(srcRoot, "json-interactions");
-  try {
-    const files = (await readdir(dir)).filter((f) => f.endsWith(".json")).sort();
-    const catalogs = [];
-    for (const f of files) {
-      const json = await readJsonSafe(join(dir, f));
-      if (json) catalogs.push(json);
+  const localDir = join(srcRoot, "json-interactions");
+  const genDir = join(srcRoot, "json-interactions", ".generated");
+  async function readDirSafe(dir) {
+    try {
+      const files = (await readdir(dir)).filter((f) => f.endsWith(".json")).sort();
+      const catalogs = [];
+      for (const f of files) {
+        const json = await readJsonSafe(join(dir, f));
+        if (json) catalogs.push(json);
+      }
+      return catalogs;
+    } catch {
+      return [];
     }
-    return catalogs;
-  } catch {
-    return [];
   }
+  const local = await readDirSafe(localDir);
+  const generated = await readDirSafe(genDir);
+  // Order matters: later catalogs override earlier ones; generated should take precedence
+  return [...local, ...generated];
 }
 
 function extractOverridesFromComponentJson(json) {

--- a/scripts/generate-json-interactions-from-plugins.js
+++ b/scripts/generate-json-interactions-from-plugins.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Generate per-plugin interaction catalogs under catalog/json-interactions/.generated
+ * based on served plugin data (public/json-sequences + plugin-manifest).
+ *
+ * Strategy (Phase 1):
+ * - Reuse derive-external-topics.js to build a single derived interactions catalog
+ * - Split that catalog into per-group files using the first segment of the route key
+ * - Choose the group's "plugin" field as the most frequent pluginId among its routes
+ * - Write JSON files to catalog/json-interactions/.generated/<group>.json
+ *
+ * Notes:
+ * - generate-interaction-manifest will read .generated catalogs and merge with any
+ *   hand-authored json-interactions/*.json (generated should take precedence in order)
+ */
+
+import { promises as fs } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { generateExternalInteractionsCatalog } from './derive-external-topics.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..');
+
+async function ensureDir(dir) {
+  await fs.mkdir(dir, { recursive: true }).catch(() => {});
+}
+
+function groupRoutesByFirstSegment(routesObj) {
+  const groups = new Map();
+  for (const [route, def] of Object.entries(routesObj || {})) {
+    const first = (route || '').split('.')[0] || 'misc';
+    if (!groups.has(first)) groups.set(first, { routes: {}, pluginCounts: new Map() });
+    const g = groups.get(first);
+    g.routes[route] = def;
+    const pid = def?.pluginId;
+    if (pid) g.pluginCounts.set(pid, (g.pluginCounts.get(pid) || 0) + 1);
+  }
+  return groups;
+}
+
+function pickGroupPluginId(pluginCounts) {
+  let best = null;
+  let n = -1;
+  for (const [pid, count] of pluginCounts.entries()) {
+    if (count > n) { best = pid; n = count; }
+  }
+  return best || 'Plugin';
+}
+
+export async function generateJsonInteractionsFromPlugins() {
+  const outDir = join(rootDir, 'catalog', 'json-interactions', '.generated');
+  await ensureDir(outDir);
+
+  const derived = await generateExternalInteractionsCatalog();
+  const groups = groupRoutesByFirstSegment(derived?.routes || {});
+
+  const written = [];
+  for (const [group, { routes, pluginCounts }] of groups.entries()) {
+    const pluginId = pickGroupPluginId(pluginCounts);
+    const outPath = join(outDir, `${group}.json`);
+    const json = { plugin: pluginId, routes };
+    await fs.writeFile(outPath, JSON.stringify(json, null, 2) + '\n', 'utf-8');
+    written.push(outPath);
+  }
+
+  return written;
+}
+
+async function main() {
+  const files = await generateJsonInteractionsFromPlugins();
+  console.log(`🧩 Generated ${files.length} interaction catalog(s) under catalog/json-interactions/.generated`);
+}
+
+// Run when executed directly
+import { fileURLToPath as _fileURLToPath } from 'url';
+const _isMain = _fileURLToPath(import.meta.url) === __filename;
+if (_isMain) {
+  main().catch((err) => {
+    console.error('❌ Failed to generate json-interactions from plugins:', err);
+    process.exit(1);
+  });
+}
+

--- a/tests/json-interactions-generation.spec.ts
+++ b/tests/json-interactions-generation.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+// Integration guard: the generator should create .generated catalogs from served data
+// Relies on pretest having synced public/json-sequences from plugins
+
+describe('json-interactions generator (Phase 1, .generated)', () => {
+  it('generates per-plugin catalogs under catalog/json-interactions/.generated', () => {
+    const script = path.join(process.cwd(), 'scripts', 'generate-json-interactions-from-plugins.js');
+    const r = spawnSync(process.execPath, [script], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    if (r.status !== 0) {
+      // helpful output if it fails
+      // eslint-disable-next-line no-console
+      console.error((r.stdout || '') + '\n' + (r.stderr || ''));
+    }
+    expect(r.status).toBe(0);
+
+    const outDir = path.join(process.cwd(), 'catalog', 'json-interactions', '.generated');
+    const libPath = path.join(outDir, 'library.json');
+    expect(existsSync(libPath)).toBe(true);
+
+    const json = JSON.parse(readFileSync(libPath, 'utf8'));
+    expect(json).toBeTruthy();
+    expect(json.routes && typeof json.routes === 'object').toBe(true);
+
+    // Should include at least the core library load route derived from served sequences
+    expect(Object.keys(json.routes)).toEqual(expect.arrayContaining(['library.load']));
+  });
+});
+


### PR DESCRIPTION
Implements Phase 1 of #229: generate per-plugin interaction catalogs from plugin-served data and integrate into pre:manifests.

What changed
- New script: scripts/generate-json-interactions-from-plugins.js (module+CLI)
  - Reuses derive-external-topics to derive interactions, splits by first route segment
  - Writes catalogs to catalog/json-interactions/.generated/<group>.json
- generate-interaction-manifest.js
  - Now reads .generated catalogs alongside json-interactions (generated takes precedence)
- package.json
  - pre:manifests runs the generator before generate-interaction-manifest
- Tests
  - tests/json-interactions-generation.spec.ts: integration guard that generator runs and produces library.json with routes

Why
- Keeps json-interactions in sync with plugin-served sequences; removes need to hand-maintain host-side catalogs (Phase 2 will remove hand-authored files)

Verification
- npm test → all tests pass (including new generator test)
- npm run build → successful; pre:manifests prints generated .generated catalogs and produces interaction-manifest.json

Next (Phase 2)
- Remove/ignore hand-authored catalog/json-interactions/*.json and rely solely on .generated
- Add ADR (ADR-00XX) describing the decision and migration

Closes #229 (Phase 1), with a follow-up PR planned for Phase 2.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author