### PR TITLE
feat(#235): Wire Delete key to publish canvas.component.delete.requested

### DIFF
--- a/src/ui/App/App.tsx
+++ b/src/ui/App/App.tsx
@@ -36,10 +36,21 @@ export default function App() {
       return true;
     };
 
-    if (wireCanvasDeselect() && wireEscapeDeselect()) return;
+    const wireDeleteSelected = () => {
+      const conductor = (window as any).RenderX?.conductor;
+      if (!conductor) return false;
+
+      window.addEventListener("keydown", async (e) => {
+        if (e.key === "Delete") await EventRouter.publish("canvas.component.delete.requested", {}, conductor);
+      });
+      return true;
+    };
+
+
+    if (wireCanvasDeselect() && wireEscapeDeselect() && wireDeleteSelected()) return;
 
     const observer = new MutationObserver(() => {
-      if (wireCanvasDeselect() && wireEscapeDeselect()) {
+      if (wireCanvasDeselect() && wireEscapeDeselect() && wireDeleteSelected()) {
         observer.disconnect();
       }
     });


### PR DESCRIPTION
This PR wires the Delete key to trigger the canvas component delete sequence.

Changes
- In App.tsx, add keydown listener that publishes `canvas.component.delete.requested` via EventRouter when `e.key === "Delete"`
- Mirror the existing Escape wiring for `canvas.component.deselect.requested`

Why
- The canvas-component has a delete sequence; users expect pressing Delete to remove the selected component.

Validation
- Built locally: `npm run build` (success)
- Lint: `npm run lint` (clean)
- Unit tests: `npm test` (all passing)

Notes
- No plugin changes; topics and sequences are already defined by plugin packages.

Closes #235

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author