### PR TITLE
feat(#237): Externalize JSON components via @renderx-plugins/components (steps 1–3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,14 @@ Script / CLI flags (all accept `--srcRoot` and `--outPublic` where applicable):
 | `scripts/generate-interaction-manifest.js` | Builds interaction-manifest.json | `--srcRoot`, `--outPublic`            |
 | `scripts/generate-topics-manifest.js`      | Builds topics-manifest.json      | `--srcRoot`, `--outPublic`            |
 | `scripts/generate-layout-manifest.js`      | Copies layout manifest           | `--srcRoot`, `--outPublic`            |
-| `scripts/sync-json-components.js`          | Copies component JSON            | `--srcRoot`, `--outPublic`            |
+| `scripts/sync-json-components.js`          | Copies component JSON; discovers node_modules packages declaring `renderx.components` (prefers package over local) | `--srcRoot`, `--outPublic`            |
 | `scripts/sync-json-sequences.js`           | Copies sequence catalogs         | `--srcRoot`, `--outPublic`            |
 | `scripts/sync-plugins.js`                  | Copies plugin manifest(s)        | `--srcRoot`, `--outPublic`            |
 | `scripts/build-artifacts.js`               | Full artifact bundle             | `--srcRoot`, `--outDir`               |
 | `scripts/copy-artifacts-to-public.js`      | Consume existing artifacts       | `ARTIFACTS_DIR` env or first arg path |
+
+
+> Note: The host now consumes component catalogs from external packages. Any package in node_modules with a package.json field `renderx.components: ["<dir>"]` will be discovered and copied into `public/json-components/`. If the same file exists both in a package and in the local `catalog/json-components/`, the package version wins to avoid duplication.
 
 On startup the host logs a summary like:
 

--- a/docs/adr/ADR-0035 — Externalize JSON Components to NPM and Discovery via renderx.components.md
+++ b/docs/adr/ADR-0035 — Externalize JSON Components to NPM and Discovery via renderx.components.md
@@ -1,0 +1,69 @@
+# ADR-0035 — Externalize JSON Components to NPM and Discovery via `renderx.components`
+
+- Status: Accepted
+- Date: 2025-09-24
+- Related Issue: https://github.com/BPMSoftwareSolutions/renderx-plugins-demo/issues/237
+
+## Context
+
+This repository is a thin host and should not own plugin/component data. Historically, JSON component catalogs (e.g., button.json, input.json) lived under `catalog/json-components/` and were copied to `public/json-components/` for the dev server and build steps. As part of decoupling and reuse, component JSON catalogs are being externalized to a separate NPM package so multiple hosts can consume them without copying source.
+
+The new package, `@renderx-plugins/components` (>= 0.1.0), publishes one or more directories that contain JSON component definitions. Packages declare these directories using a `renderx.components` field in their `package.json`.
+
+Example:
+
+```
+{
+  "name": "@renderx-plugins/components",
+  "version": "0.1.0",
+  "renderx": {
+    "components": ["json-components"]
+  }
+}
+```
+
+## Decision
+
+- The host will discover component catalogs from installed packages by scanning `node_modules` for packages whose `package.json` contains a `renderx.components` string array. Each listed directory is copied to `public/json-components/`.
+- During the transition, any repo-local `catalog/json-components/` files will also be copied only if a file with the same name was not already provided by a package (i.e., prefer package over local to avoid duplication and drift).
+- Build artifacts continue to include `json-components/` by reusing existing `scripts/build-artifacts.js` copy logic (no change required).
+
+## Changes
+
+- `scripts/sync-json-components.js` enhanced to:
+  - Discover and copy from `node_modules/*` and `node_modules/@scope/*` when `renderx.components` is declared
+  - Copy local `catalog/json-components/` files only for items not already provided by packages
+  - Default `--srcRoot` remains `catalog/`; `--outPublic` remains `public/`
+- Documentation updated in `README.md` to describe the discovery mechanism and precedence.
+- Added this ADR documenting the boundary and approach.
+
+## Alternatives Considered
+
+- Keeping host-owned `json-components` only — rejected due to coupling and duplication across hosts.
+- Hardcoding specific package names — rejected; discovery via manifest field is more extensible and avoids hardcoded lists.
+
+## Consequences
+
+- The host dev server and builds no longer require local `catalog/json-components/` to function, provided `@renderx-plugins/components` (or compatible packages) are installed.
+- Teams can publish additional component sets without modifying the host; the host will discover them via the `renderx.components` field.
+- If both local and package catalogs exist, the package versions take precedence to avoid duplication. Local files can be removed once migration is complete.
+
+## Migration Notes
+
+- Install the components package in the host: `npm install @renderx-plugins/components@0.1.0`.
+- Ensure `npm run pre:manifests` (or `npm run dev` / `npm run build`) executes `scripts/sync-json-components.js` so `public/json-components/` is populated from packages.
+
+## Acceptance Criteria (from Issue #237)
+
+- Host dev server populates `public/json-components/` from the package (no local required)
+- Library panel and drag/drop continue to work as before
+- ESLint rules over `public/json-components` remain green
+- CI passes with all tests and lint
+
+## References
+
+- Issue #237
+- `scripts/sync-json-components.js`
+- `scripts/build-artifacts.js`
+- `src/domain/components/inventory/inventory.service.ts` (unchanged)
+

--- a/eslint-rules/require-plugin-manifest-fragment.js
+++ b/eslint-rules/require-plugin-manifest-fragment.js
@@ -139,7 +139,8 @@ export default {
           const keywords = Array.isArray(pkgJson.keywords)
             ? pkgJson.keywords.map(String)
             : [];
-          const isPlugin = keywords.includes("renderx-plugin") || !!pkgJson.renderx;
+          const rx = pkgJson.renderx || null;
+          const isPlugin = keywords.includes("renderx-plugin") || !!(rx && (Array.isArray(rx.plugins) || typeof rx.manifest === "string"));
           if (!isPlugin) return {};
 
           const hasFragment = hasManifestFragment(pkgRoot, pkgJson);
@@ -173,7 +174,8 @@ export default {
             const keywords = Array.isArray(pkgJson.keywords)
               ? pkgJson.keywords.map(String)
               : [];
-            const isPlugin = keywords.includes("renderx-plugin") || !!pkgJson.renderx;
+            const rx = pkgJson.renderx || null;
+            const isPlugin = keywords.includes("renderx-plugin") || !!(rx && (Array.isArray(rx.plugins) || typeof rx.manifest === "string"));
             if (!isPlugin) continue;
             if (!hasManifestFragment(dir, pkgJson)) {
               offenders.push(name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "dependencies": {
         "@renderx-plugins/canvas": "^0.1.0-rc.3",
         "@renderx-plugins/canvas-component": "^0.1.0-rc.19",
+        "@renderx-plugins/components": "^0.1.0",
         "@renderx-plugins/control-panel": "^0.1.0-rc.7",
         "@renderx-plugins/header": "^0.1.1",
         "@renderx-plugins/host-sdk": "^0.3.0",
@@ -1156,6 +1157,14 @@
       "version": "0.1.0-rc.19",
       "resolved": "https://registry.npmjs.org/@renderx-plugins/canvas-component/-/canvas-component-0.1.0-rc.19.tgz",
       "integrity": "sha512-Zq88TwLOGG96f5Q8CkgQrww52Q6zStiYr+9F6K2giiOQbeG8boEuEVNqsY3EEjqOfgQFv4y7Sb5jwQu3HPAXXA=="
+    },
+    "node_modules/@renderx-plugins/components": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@renderx-plugins/components/-/components-0.1.0.tgz",
+      "integrity": "sha512-wDsqzXJLHZS/JpJDF3tA/PMfrncXI8rD69SMxx/MzSqfaw+xR3bZhLJLEuJj985ANdI/2BKvVNRaNqbMrjM/dQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@renderx-plugins/control-panel": {
       "version": "0.1.0-rc.7",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@renderx-plugins/canvas": "^0.1.0-rc.3",
     "@renderx-plugins/canvas-component": "^0.1.0-rc.19",
+    "@renderx-plugins/components": "^0.1.0",
     "@renderx-plugins/control-panel": "^0.1.0-rc.7",
     "@renderx-plugins/header": "^0.1.1",
     "@renderx-plugins/host-sdk": "^0.3.0",

--- a/scripts/sync-json-components.js
+++ b/scripts/sync-json-components.js
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
 /**
- * Sync script to copy json-components/ to public/json-components/
- * This ensures the dev server and build process have the latest component definitions.
+ * Sync component JSON catalogs to public/json-components/.
+ * Enhancements:
+ *  - Discovers node_modules packages that declare `renderx.components` in their package.json
+ *    and copies their component trees first
+ *  - Then (for transition) copies any repo-local catalog/json-components files that were not
+ *    already provided by a package (prefer package to avoid duplication)
  */
 
-import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
-import { join, dirname } from 'path';
+import { readdir, readFile, writeFile, mkdir, stat } from 'fs/promises';
+import { join, dirname, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -23,42 +27,111 @@ function getArg(name, def) {
   if (nxt && !nxt.startsWith('--')) return nxt;
   return def;
 }
-const srcRoot = getArg('--srcRoot', rootDir);
+const srcRoot = getArg('--srcRoot', join(rootDir, 'catalog'));
 const outPublic = getArg('--outPublic', join(rootDir, 'public'));
 
-const sourceDir = join(srcRoot, 'json-components');
+const localComponentsDir = join(srcRoot, 'json-components');
 const targetDir = join(outPublic, 'json-components');
+const nodeModulesDir = join(rootDir, 'node_modules');
 
 async function ensureDir(dir) {
-  try {
-    await mkdir(dir, { recursive: true });
-  } catch (err) {
-    if (err.code !== 'EEXIST') throw err;
-  }
+  try { await mkdir(dir, { recursive: true }); } catch (err) { if (err.code !== 'EEXIST') throw err; }
 }
 
 async function copyFile(source, target) {
   const content = await readFile(source);
+  await ensureDir(dirname(target));
   await writeFile(target, content);
 }
 
+async function safeJsonRead(p) {
+  try { return JSON.parse(await readFile(p, 'utf-8')); } catch { return null; }
+}
+
+async function existsDir(p) {
+  try { return (await stat(p)).isDirectory(); } catch { return false; }
+}
+
+async function listJsonFiles(dir) {
+  try {
+    const files = await readdir(dir);
+    return files.filter(f => f.toLowerCase().endsWith('.json')).map(f => join(dir, f));
+  } catch { return []; }
+}
+
+async function discoverComponentPackageDirs() {
+  const results = [];
+  if (!(await existsDir(nodeModulesDir))) return results;
+
+  // Helper to process a single package directory path
+  async function processPackage(pkgDir) {
+    const pkgJson = await safeJsonRead(join(pkgDir, 'package.json'));
+    const components = pkgJson?.renderx?.components;
+    if (Array.isArray(components) && components.length) {
+      for (const rel of components) {
+        const abs = resolve(pkgDir, rel);
+        if (await existsDir(abs)) results.push(abs);
+      }
+    }
+  }
+
+  // Scan node_modules root
+  const top = await readdir(nodeModulesDir).catch(() => []);
+  for (const name of top) {
+    if (name.startsWith('.')) continue;
+    const p = join(nodeModulesDir, name);
+    const isDir = await existsDir(p);
+    if (!isDir) continue;
+    if (name.startsWith('@')) {
+      // Scoped packages
+      const scoped = await readdir(p).catch(() => []);
+      for (const sub of scoped) {
+        const subPath = join(p, sub);
+        if (await existsDir(subPath)) await processPackage(subPath);
+      }
+    } else {
+      await processPackage(p);
+    }
+  }
+  return results;
+}
+
 async function syncJsonComponents() {
-  console.log('🔄 Syncing json-components/ to public/json-components/...');
-  
+  console.log('🔄 Syncing component catalogs to public/json-components ...');
+
   try {
     await ensureDir(targetDir);
-    
-    const files = await readdir(sourceDir);
-    const jsonFiles = files.filter(f => f.endsWith('.json'));
-    
-    for (const file of jsonFiles) {
-      const sourcePath = join(sourceDir, file);
-      const targetPath = join(targetDir, file);
-      await copyFile(sourcePath, targetPath);
-      console.log(`  ✅ Copied ${file}`);
+
+    const already = new Set();
+
+    // 1) Copy from discovered packages (preferred)
+    const pkgDirs = await discoverComponentPackageDirs();
+    if (pkgDirs.length) console.log(`  📦 Found ${pkgDirs.length} package component dir(s)`);
+    for (const dir of pkgDirs) {
+      const files = await listJsonFiles(dir);
+      for (const abs of files) {
+        const fileName = abs.split(sep).pop();
+        if (!fileName) continue;
+        const out = join(targetDir, fileName);
+        await copyFile(abs, out);
+        already.add(fileName);
+        console.log(`  ✅ [pkg] ${fileName}`);
+      }
     }
-    
-    console.log(`✨ Synced ${jsonFiles.length} JSON component files`);
+
+    // 2) Copy from local catalog/json-components for files not already provided
+    const localFiles = await listJsonFiles(localComponentsDir);
+    let localCopied = 0;
+    for (const abs of localFiles) {
+      const fileName = abs.split(sep).pop();
+      if (!fileName || already.has(fileName)) continue; // prefer package
+      const out = join(targetDir, fileName);
+      await copyFile(abs, out);
+      localCopied++;
+      console.log(`  ↪️  [local] ${fileName}`);
+    }
+
+    console.log(`✨ Sync complete. Packages: ${already.size} file(s), Local added: ${localCopied} file(s)`);
   } catch (error) {
     console.error('❌ Failed to sync json-components:', error);
     process.exit(1);


### PR DESCRIPTION
Implements steps 1–3 of Externalize JSON Components into @renderx-plugins/components package (#237).

Summary:
- Install @renderx-plugins/components@0.1.0 and consume its component JSON
- Enhance scripts/sync-json-components.js to discover node_modules packages declaring `renderx.components` and copy their component trees to public/json-components; prefer package over local to avoid duplication
- Keep existing browser fetch path unchanged; build-artifacts continues to copy json-components
- Relax ESLint rule (require-plugin-manifest-fragment) so component-only packages (renderx.components) are not required to provide plugin manifest fragments
- Update README to document discovery mechanism and add ADR-0035 documenting the boundary and discovery approach

Verification:
- npm run pre:manifests populates public/json-components from the package (no local required)
- Lint and unit tests pass locally
- npm run build succeeds

Notes:
- This PR purposefully does not remove local catalog/json-components yet; they are ignored when a package provides the same files (per preference: package wins).


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author