### PR TITLE
chore(ci): print app logs to job output on E2E failure (ref #238)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,32 @@ jobs:
           key: cypress-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Build + Preview + Cypress E2E
         run: npm run e2e:cypress
+      - name: Print app logs on failure
+        if: failure()
+        run: |
+          echo "=== .logs (if present) ==="
+          if [ -d ".logs" ]; then
+            ls -la .logs || true
+            for f in ./.logs/*.log; do
+              [ -e "$f" ] || continue
+              echo "::group::$f"
+              tail -n 400 "$f" || true
+              echo "::endgroup::"
+            done
+          else
+            echo "No .logs directory found."
+          fi
+          echo "=== cypress/artifacts (if present) ==="
+          if [ -d "cypress/artifacts" ]; then
+            find cypress/artifacts -type f -name "*.log" | while read -r f; do
+              echo "::group::$f"
+              tail -n 400 "$f" || true
+              echo "::endgroup::"
+            done
+          else
+            echo "No cypress/artifacts directory found."
+          fi
+
       - name: Upload Cypress videos on failure
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This cherry-picks the workflow tweak that prints app logs to the job output on E2E failure, to speed up remote CI triage.

- Adds a failure-only step to e2e_cypress that tails `/.logs/*.log` and `cypress/artifacts/**/*.log`
- Uses `::group::` sections for readability
- No product code changes

Rationale
- When E2E flakes or fails, we can immediately see app + Cypress artifacts in the job output without downloading artifacts.

Notes
- This is a pure CI ergonomics change. Intended to help diagnose Issue #238.

Ref: #238

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author