### PR TITLE
fix(#238): add startup debug/validation and topics guard test; stabilize readiness gating

### DIFF
--- a/cypress/e2e/library-drop.cy.ts
+++ b/cypress/e2e/library-drop.cy.ts
@@ -17,7 +17,7 @@ describe('Library → Canvas drop creates component', () => {
 
   it('drags button component from Library and drops onto Canvas', () => {
     // Visit early and hook console.log for sequence detection
-    cy.visit('/', {
+    cy.visit('/?debug=1', {
       onBeforeLoad(win) {
         const originalLog = win.console.log;
         const originalWarn = win.console.warn;

--- a/tests/topics-manifest-guard.spec.ts
+++ b/tests/topics-manifest-guard.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function loadJson(p: string) {
+  const raw = readFileSync(p, 'utf8');
+  return JSON.parse(raw);
+}
+
+describe('Topics manifest guardrails', () => {
+  const root = process.cwd();
+  const topicsPath = path.join(root, 'topics-manifest.json');
+  const pluginManifestPath = path.join(root, 'public', 'plugins', 'plugin-manifest.json');
+
+  const topicsJson = loadJson(topicsPath);
+  const topics = topicsJson?.topics || {};
+  const keys = Object.keys(topics);
+
+  it('includes critical Control Panel topics with routes', () => {
+    const required = [
+      'control.panel.ui.init.requested',
+      'control.panel.ui.render.requested',
+      'control.panel.ui.field.change.requested',
+      'control.panel.selection.show.requested',
+    ];
+
+    for (const k of required) {
+      expect(keys, `topics-manifest contains ${k}`).toContain(k);
+      const routes = Array.isArray(topics[k]?.routes) ? topics[k].routes : [];
+      expect(routes.length, `${k} routes length`).toBeGreaterThan(0);
+      // Control Panel routes should be handled by ControlPanelPlugin
+      const pluginIds = routes.map((r: any) => r?.pluginId).filter(Boolean);
+      expect(pluginIds, `${k} plugin ids`).toContain('ControlPanelPlugin');
+    }
+  });
+
+  it('classifies canvas drag topics correctly (start/end notify-only, move routed)', () => {
+    // start/end notify-only
+    expect(keys).toContain('canvas.component.drag.start');
+    expect(keys).toContain('canvas.component.drag.end');
+    expect(Array.isArray(topics['canvas.component.drag.start']?.routes) ? topics['canvas.component.drag.start'].routes.length : 0)
+      .toBe(0);
+    expect(Array.isArray(topics['canvas.component.drag.end']?.routes) ? topics['canvas.component.drag.end'].routes.length : 0)
+      .toBe(0);
+
+    // move is routed
+    expect(keys).toContain('canvas.component.drag.move');
+    const moveRoutes = Array.isArray(topics['canvas.component.drag.move']?.routes) ? topics['canvas.component.drag.move'].routes : [];
+    expect(moveRoutes.length).toBeGreaterThan(0);
+  });
+
+  it('plugin-manifest contains ControlPanelPlugin (source of truth for runtime)', () => {
+    const pluginManifest = loadJson(pluginManifestPath);
+    const ids: string[] = Array.isArray(pluginManifest?.plugins)
+      ? pluginManifest.plugins.map((p: any) => p?.id).filter((s: any) => typeof s === 'string' && s.length)
+      : [];
+    expect(ids).toContain('ControlPanelPlugin');
+  });
+});
+


### PR DESCRIPTION
This PR implements Step 1 isolation improvements for issue #238.

Summary
- Add optional startup debug + validation (enabled via query params)
  - /?debug=1 logs mounted plugin IDs, runtime sequence IDs, and manifest counts
  - /?failFast=1 checks for presence of key topics and throws early if missing
- Guardrail unit test to catch derivation regressions before E2E/CI
  - tests/topics-manifest-guard.spec.ts asserts Control Panel topics exist and are routed, and drag topics are correctly classified
- Stabilize E2E readiness gating in library-drop spec
  - Use counts-based readiness (consistent with 00-startup-plugins-loaded)
  - Visit with /?debug=1 to surface diagnostics in CI output without affecting functionality

Verification
- npm run build → success (derived topics 63, interactions 42; aggregated plugins 8)
- npm test → all green (6 files, 8 tests)
- E2E single spec (library-drop.cy.ts) → green locally

Notes
- No dependency changes
- Does not enforce fail-fast by default; CI can opt-in by visiting /?failFast=1 when we want strict runtime validation

Closes #238 (Step 1 isolation logging + TDD guardrails).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author