### PR TITLE
feat: Add keyboard shortcuts for copy/paste (Ctrl+C/V and Cmd+C/V)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@renderx-plugins/canvas": "^0.1.0-rc.3",
-        "@renderx-plugins/canvas-component": "^1.0.10",
+        "@renderx-plugins/canvas-component": "^1.0.11",
         "@renderx-plugins/components": "0.1.1",
         "@renderx-plugins/control-panel": "0.1.0-rc.9",
         "@renderx-plugins/header": "^0.1.1",
@@ -1437,9 +1437,9 @@
       }
     },
     "node_modules/@renderx-plugins/canvas-component": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@renderx-plugins/canvas-component/-/canvas-component-1.0.10.tgz",
-      "integrity": "sha512-/ONHFxVVeT7OHfQeITkOqCZIg60IhPDA2qGkbfW7upn4ihEmhEm6176wsg+vaewv5LukPC33GCIQrDIpKEOFOg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@renderx-plugins/canvas-component/-/canvas-component-1.0.11.tgz",
+      "integrity": "sha512-HnZV0vtoPniOBdZ87ccmR+2Bms/GemAqrnnDV2OKqq4Avs2Zxrv6GFPdBO5IAvfQUFmKq3re9ywlSPJb/bJVVA==",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "dependencies": {
         "@renderx-plugins/canvas": "^0.1.0-rc.3",
-        "@renderx-plugins/canvas-component": "^1.0.8",
+        "@renderx-plugins/canvas-component": "^1.0.10",
         "@renderx-plugins/components": "0.1.1",
         "@renderx-plugins/control-panel": "0.1.0-rc.9",
         "@renderx-plugins/header": "^0.1.1",
@@ -1437,9 +1437,9 @@
       }
     },
     "node_modules/@renderx-plugins/canvas-component": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@renderx-plugins/canvas-component/-/canvas-component-1.0.8.tgz",
-      "integrity": "sha512-8LblV6F1iQyPY2v696401DgZe1OaxDHdchRK+QEwi57GLdnRrHU15vjOWnhQKkiq0UiFgCBnEUOD/xhz+3bfeQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@renderx-plugins/canvas-component/-/canvas-component-1.0.10.tgz",
+      "integrity": "sha512-/ONHFxVVeT7OHfQeITkOqCZIg60IhPDA2qGkbfW7upn4ihEmhEm6176wsg+vaewv5LukPC33GCIQrDIpKEOFOg==",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@renderx-plugins/canvas": "^0.1.0-rc.3",
-    "@renderx-plugins/canvas-component": "^1.0.10",
+    "@renderx-plugins/canvas-component": "^1.0.11",
     "@renderx-plugins/components": "0.1.1",
     "@renderx-plugins/control-panel": "0.1.0-rc.9",
     "@renderx-plugins/header": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@renderx-plugins/canvas": "^0.1.0-rc.3",
-    "@renderx-plugins/canvas-component": "^1.0.8",
+    "@renderx-plugins/canvas-component": "^1.0.10",
     "@renderx-plugins/components": "0.1.1",
     "@renderx-plugins/control-panel": "0.1.0-rc.9",
     "@renderx-plugins/header": "^0.1.1",

--- a/src/core/manifests/uiEvents.json
+++ b/src/core/manifests/uiEvents.json
@@ -20,6 +20,34 @@
     "event": "keydown",
     "guard": { "key": "Delete" },
     "publish": { "topic": "canvas.component.delete.requested", "payload": {} }
+  },
+  {
+    "id": "canvas.copy.onCtrlC",
+    "target": { "window": true },
+    "event": "keydown",
+    "guard": { "key": "c", "ctrlKey": true, "metaKey": false },
+    "publish": { "topic": "canvas.component.copy", "payload": {} }
+  },
+  {
+    "id": "canvas.copy.onCmdC",
+    "target": { "window": true },
+    "event": "keydown",
+    "guard": { "key": "c", "metaKey": true, "ctrlKey": false },
+    "publish": { "topic": "canvas.component.copy", "payload": {} }
+  },
+  {
+    "id": "canvas.paste.onCtrlV",
+    "target": { "window": true },
+    "event": "keydown",
+    "guard": { "key": "v", "ctrlKey": true, "metaKey": false },
+    "publish": { "topic": "canvas.component.paste", "payload": {} }
+  },
+  {
+    "id": "canvas.paste.onCmdV",
+    "target": { "window": true },
+    "event": "keydown",
+    "guard": { "key": "v", "metaKey": true, "ctrlKey": false },
+    "publish": { "topic": "canvas.component.paste", "payload": {} }
   }
 ]
 

--- a/src/ui/events/wiring.ts
+++ b/src/ui/events/wiring.ts
@@ -7,6 +7,10 @@ export type UiEventDef = {
   options?: AddEventListenerOptions | boolean;
   guard?: {
     key?: string;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    shiftKey?: boolean;
+    altKey?: boolean;
     notClosestMatch?: string;
   };
   publish: { topic: string; payload?: any };
@@ -40,6 +44,23 @@ export function wireUiEvents(defs: UiEventDef[]): () => void {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const key = (e as any).key as string | undefined;
           if (key !== def.guard.key) return;
+        }
+        // Check modifier keys
+        if (def.guard?.ctrlKey !== undefined) {
+          const ke = e as KeyboardEvent;
+          if (ke.ctrlKey !== def.guard.ctrlKey) return;
+        }
+        if (def.guard?.metaKey !== undefined) {
+          const ke = e as KeyboardEvent;
+          if (ke.metaKey !== def.guard.metaKey) return;
+        }
+        if (def.guard?.shiftKey !== undefined) {
+          const ke = e as KeyboardEvent;
+          if (ke.shiftKey !== def.guard.shiftKey) return;
+        }
+        if (def.guard?.altKey !== undefined) {
+          const ke = e as KeyboardEvent;
+          if (ke.altKey !== def.guard.altKey) return;
         }
         if (def.guard?.notClosestMatch) {
           const target = e.target as HTMLElement | null;


### PR DESCRIPTION
- Enhanced UI event wiring to support modifier key guards (ctrlKey, metaKey, shiftKey, altKey)
- Added cross-platform keyboard shortcuts in uiEvents.json
  - Ctrl+C / Cmd+C for copy
  - Ctrl+V / Cmd+V for paste
- Updated canvas-component plugin to v1.0.10 with proper copy/paste routing
- Topics canvas.component.copy and canvas.component.paste now have proper routes